### PR TITLE
docs: align repository with Concept V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,100 @@
 # ⚔️ pomodoro-dnd
 
-> Ein Pomodoro-Timer im D&D-Stil. Arbeiten heißt **auf Quest gehen**, Pause heißt **rasten**,
-> und nach jeder Quest darfst du eine **Truhe öffnen**. Allein — oder als **Party** mit einem
-> 5-stelligen Code, bei der alle dieselbe Uhr sehen.
+> Eine Cozy-Fantasy-Fokus-App: Arbeit wird zur Quest, echte Fokuszeit bewegt den Charakter durch eine illustrierte Welt und lässt das persönliche Lager wachsen.
 
-**Ziel-Domain:** `pomodoro.lang-jamin.de`
-**Status:** ✅ Konzept vollständig — alle Konflikte mit Konzept V1 entschieden, M1 kann starten
-**Visueller Draft:** [alle elf Screens als Canvas](https://claude.ai/code/artifact/671894a8-8452-4e21-a32d-c48e88dea90e) · Quellen unter [`design/`](design/)
-**Owner:** @yamahabenny-gif · **Freigabe:** Release Team (`#release`)
+**Ziel-Domain:** `pomodoro.lang-jamin.de`  
+**Status:** Concept V2 ist die verbindliche Produktspezifikation; Umsetzung startet mit einem Vertical Slice.  
+**Owner:** @yamahabenny-gif
 
 ---
 
-## Inhaltsverzeichnis
+## Source of Truth
+
+**[docs/CONCEPT.md](docs/CONCEPT.md)** ist die verbindliche Quelle für Produktvision, Gameplay, Progression, Charaktere, Party, UX, Art Direction, Accessibility und MVP/Roadmap.
+
+Detaildokumente konkretisieren das Konzept, dürfen ihm aber nicht widersprechen:
 
 | Dokument | Inhalt |
 |---|---|
-| **[docs/KONZEPT-ABGLEICH.md](docs/KONZEPT-ABGLEICH.md)** | **Abgleich mit Konzept V1 — hier zuerst lesen** |
-| [docs/CONCEPT.md](docs/CONCEPT.md) | Spielkonzept: Klassen, Quests, Rast, Truhen, Loot |
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Tech-Stack, Datenmodell, Deployment |
-| [docs/SYNC-PROTOCOL.md](docs/SYNC-PROTOCOL.md) | **Kernstück:** wie die Party dieselbe Uhr sieht |
-| [docs/DESIGN-SYSTEM.md](docs/DESIGN-SYSTEM.md) | Farben, Typografie, Spacing, Motion, A11y |
-| [docs/ART-DIRECTION.md](docs/ART-DIRECTION.md) | Hybrid aus Linie und Illustration, der Item-Baukasten |
-| [docs/MOTION-ENGINE.md](docs/MOTION-ENGINE.md) | Warum keine Game-Engine, und wie die Wanderung funktioniert |
-| [docs/SCREENS.md](docs/SCREENS.md) | Alle Screens von Login bis Charakterbogen |
-| [design/](design/) | Der visuelle Draft — elf Artboards als Quelldateien |
-| [docs/AGENT-SKILLS.md](docs/AGENT-SKILLS.md) | Welche Agent-Skills gelten und wofür |
-| [docs/WORKFLOW.md](docs/WORKFLOW.md) | Hashtags, Branches, Reviews, Release-Freigabe |
-| [docs/ROADMAP.md](docs/ROADMAP.md) | Meilensteine M0–M5 |
-| [docs/DECISIONS.md](docs/DECISIONS.md) | Architecture Decision Records (ADR) |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | Wie hier gearbeitet wird — **bitte zuerst lesen** |
+| [docs/CONCEPT.md](docs/CONCEPT.md) | **Concept V2 – Was und Warum** |
+| [docs/SCREENS.md](docs/SCREENS.md) | Screen- und UX-Spezifikation |
+| [docs/DESIGN-SYSTEM.md](docs/DESIGN-SYSTEM.md) | Komponenten, Tokens, Typografie, A11y |
+| [docs/ART-DIRECTION.md](docs/ART-DIRECTION.md) | visuelle Umsetzung der Cozy-Fantasy-Welt |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | technische Architektur |
+| [docs/SYNC-PROTOCOL.md](docs/SYNC-PROTOCOL.md) | Zeit- und Party-Synchronisation |
+| [docs/ROADMAP.md](docs/ROADMAP.md) | Umsetzungsphasen |
+| [docs/DECISIONS.md](docs/DECISIONS.md) | Architecture/Product Decision Records |
+| [docs/KONZEPT-ABGLEICH.md](docs/KONZEPT-ABGLEICH.md) | historischer Abgleich V1 / früherer Draft |
+| [docs/WORKFLOW.md](docs/WORKFLOW.md) | Entwicklungsworkflow |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Mitarbeit am Repository |
 
 ---
 
-## Das Konzept in 60 Sekunden
+## Das Produkt in 60 Sekunden
 
-Ein klassischer Pomodoro-Timer zählt runter. Dieser hier erzählt dabei eine Geschichte:
+1. **Charakter erstellen.** Mensch, Elf, Zwerg, Goblin oder Ork. Keine Klassen, keine Stats, keine Geschlechtsauswahl. Die Figur ist Identität, kein Build.
+2. **Im Lager ankommen.** Das Lager ist Home-Screen und Navigation: Abenteuerbuch, Rucksack, Sammlung, Signalhorn und Händler sind Teil der Welt.
+3. **Quest wählen.** 15, 25 oder 50 Minuten; später epische Abenteuer als 3×25-Minuten-Bogen. Die Quest ist die Timer-Konfiguration.
+4. **Fokussieren.** Der Charakter reist automatisch durch eine 2D-Fantasywelt. Der Timer bleibt lesbar in die Welt integriert. Während Fokus ist keine Spielinteraktion nötig.
+5. **Ankommen und rasten.** XP und Gold werden vergeben, eine Truhe wird verdient. Erst kommt die reale Pause, danach darf die Truhe geöffnet werden.
+6. **Welt wachsen lassen.** Loot ist kosmetisch und ohne Duplikate. Gold gibt Wahlfreiheit beim Händler. Sets, Erinnerungen, Begleiter und Lagerentwicklung erzählen langfristig die Geschichte investierter Fokuszeit.
+7. **Optional gemeinsam aufbrechen.** Solo ist vollständig. Party-Einladung erfolgt bevorzugt per Link, ein kurzer Code bleibt Fallback. Alle bestätigen Bereitschaft, sehen dieselbe Uhr und arbeiten dann „zusammen allein“ – ohne Chat oder Pings während Fokus.
 
-1. **Charakter wählen.** Sechs Klassen — jede bringt ein *anderes Timer-Profil* mit.
-   Der Magier arbeitet 50/10, der Schurke sprintet 15/3. Die Klassenwahl ist keine
-   Kosmetik, sie ist die Timer-Konfiguration.
-2. **Quest starten.** Der Fokus-Block ist eine Quest. Der Charakter ist unterwegs,
-   die UI wird ruhig, Benachrichtigungen gehen aus (Auto-DND, wie im Referenzprojekt).
-3. **Rasten.** Der Break ist eine Rast am Lagerfeuer. Jede vierte Rast ist eine
-   **Lange Rast** in der Taverne.
-4. **Truhe öffnen.** Nach jeder abgeschlossenen Quest gibt es eine Truhe: XP, Gold,
-   ein Item. Fünf Seltenheitsstufen von *Gewöhnlich* bis *Legendär*.
-5. **Party bilden.** Ein 5-stelliger Code — z. B. `H26HE` — und ihr seid synchron.
-   Dieselbe Quest, dieselbe verbleibende Zeit, gemeinsame Party-Truhe am Ende.
+### Leitplanken
 
-## Warum "gleiche Uhrzeit" nicht trivial ist
-
-Die naive Lösung — jeder Client startet ein `setInterval` — driftet innerhalb weniger
-Minuten sichtbar auseinander und bricht komplett, sobald ein Tab in den Hintergrund geht.
-
-Wir übernehmen stattdessen den Ansatz des Referenzprojekts
-[devmobasa/omarchy-pomodoro](https://github.com/devmobasa/omarchy-pomodoro) und
-verallgemeinern ihn: **Der Timer ist kein Countdown, sondern ein Zeitstempel.**
-
-Der Server hält pro Party genau einen `phase_started_at` (UTC) plus `phase_duration_s`.
-Jeder Client rechnet daraus lokal seine Restzeit aus und korrigiert seine eigene Uhr
-über einen gemessenen Server-Offset. Es gibt keinen "Tick" über die Leitung — nur
-Phasenwechsel. Das ist billig, robust gegen Reconnects, und ein neu beigetretenes
-Mitglied ist sofort synchron.
-
-→ Vollständige Spezifikation in [docs/SYNC-PROTOCOL.md](docs/SYNC-PROTOCOL.md)
+- **Die Welt ist das Menü.**
+- **Fokus vor Gamification.**
+- **1 Fokusminute = 1 XP.**
+- **Keine Streaks, Daily Rewards, FOMO oder Schuldmechaniken.**
+- **Keine Power-Progression.**
+- **Keine Party-Truhe oder sozialen Leistungsrankings.**
+- **Accessibility verändert nie Rewards.**
+- **Die Fokuszeit der Person ist heiliger als die Spielinszenierung.**
 
 ---
 
-## Inhalt
+## Fokuszeiten und Economy
 
-| | |
-|---|---|
-| [`content/quests.de.json`](content/quests.de.json) | **126 Quests** in elf Regionen, 514 Wegabschnitte, davon 10 epische |
-| [`content/regions.de.json`](content/regions.de.json) | Elf Regionen mit Themenwelt, Ton und Kulissen-Palette |
-| [`content/items.de.json`](content/items.de.json) | **336 Gegenstände** in 16 Töpfen, mit Sammlungssets |
-| [`lib/quests/`](lib/quests/) | Auswahl und Wegabschnitte — reine Funktionen, getestet |
-| [`lib/loot/`](lib/loot/) | Der Item-Baukasten: 576 Gegenstände aus 26 Teilen |
-| [`lib/timer/journey.ts`](lib/timer/journey.ts) | Die Wanderung als abgeleiteter Zustand |
+| Quest | Fokus | Basisgold |
+|---|---:|---:|
+| Kundschaftergang | 15 min | 3 |
+| Kurze Quest | 25 min | 5 |
+| Mittlere Quest | 50 min | 10 |
+| Episches Abenteuer | 3 × 25 min | 15 gesamt |
+
+XP entstehen pro tatsächlich fokussierter Minute. Bei vorzeitigem Abbruch bleiben diese XP erhalten; Questabschluss-Gold und Truhe gibt es nur für einen abgeschlossenen Fokusabschnitt.
+
+Loot nutzt vier Seltenheitsstufen: **Gewöhnlich 60 % · Ungewöhnlich 27 % · Selten 11 % · Außergewöhnlich 2 %**. Wenn eine Truhe ein Item enthält, ist es neu.
+
+---
+
+## Aktueller Content und vorhandene Logik
+
+Das Repository enthält bereits einen umfangreichen Content- und Logikbestand, darunter Quest-/Regionsdaten, Itemkataloge, Lootlogik und zeitbasierte Journey-Logik. Bestehender Content darf weiterverwendet werden, sofern er Concept V2 entspricht; widersprechende Texte, Tests und Annahmen werden schrittweise migriert.
 
 ```bash
-npm test        # 77 Tests über Questpool, Katalog, Ziehung und Wanderung
+npm test
 npm run typecheck
 ```
 
+---
+
+## Umsetzungsreihenfolge
+
+1. **Vertical Slice:** Einstieg → Account → Charakter → Lager → „Ein Licht im Unterholz“ → 15 Minuten Fokus → Abschluss → Rast → deterministische Weglaterne.
+2. **Core MVP:** 15/25/50-Quests, Progression, Loot, Ausrüstung, erste Lagerentwicklung, Settings, responsive Nutzung.
+3. **Weltvertiefung:** Händler, Sets, Begleiter, weitere Regionen und Lagerstufen.
+4. **Party:** Signalhorn, Einladungslink + Code-Fallback, Ready Check, gemeinsame Uhr, individuelle Rewards.
+5. **Epische Abenteuer:** 3×25 Minuten mit persistentem Aktfortschritt.
+6. **Langfristige Welt:** weitere Inhalte, Events und Plattformoptionen.
+
+---
+
 ## Für Mitwirkende
 
-**Alles wird hier dokumentiert.** Kein Wissen in DMs, keine ToDos im Kopf.
+Vor Produktentscheidungen zuerst [docs/CONCEPT.md](docs/CONCEPT.md) lesen. Bei einem Widerspruch zwischen älteren Dokumenten und Concept V2 gilt Concept V2; der Widerspruch soll im selben Change bereinigt oder explizit als Migration dokumentiert werden.
 
-- Jede Aufgabe ist ein **GitHub Issue**. Kein Issue → keine Arbeit.
-- Jedes Issue trägt genau einen **Zuständigkeits-Hashtag**: `#SENDEV` oder `#junDev`.
-- Alles, was nach außen geht, trägt zusätzlich `#release` und wartet auf das Release Team.
-- Jede Architektur-Entscheidung wird als ADR in [docs/DECISIONS.md](docs/DECISIONS.md) festgehalten.
-- `main` ist geschützt: Merge nur über einen Pull Request mit mindestens einem Review.
-
-Details: [CONTRIBUTING.md](CONTRIBUTING.md) · [docs/WORKFLOW.md](docs/WORKFLOW.md)
+Details zum Entwicklungsworkflow: [CONTRIBUTING.md](CONTRIBUTING.md) · [docs/WORKFLOW.md](docs/WORKFLOW.md)
 
 ## Lizenz
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Detaildokumente konkretisieren das Konzept, dürfen ihm aber nicht widersprechen
 | [docs/SCREENS.md](docs/SCREENS.md) | Screen- und UX-Spezifikation |
 | [docs/DESIGN-SYSTEM.md](docs/DESIGN-SYSTEM.md) | Komponenten, Tokens, Typografie, A11y |
 | [docs/ART-DIRECTION.md](docs/ART-DIRECTION.md) | visuelle Umsetzung der Cozy-Fantasy-Welt |
+| [docs/ASSET-BIBLE.md](docs/ASSET-BIBLE.md) | **Produktion, Formate, Layering, Audio und Motion-Assets** |
+| [docs/MOTION-ENGINE.md](docs/MOTION-ENGINE.md) | technische Bewegungslogik |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | technische Architektur |
 | [docs/SYNC-PROTOCOL.md](docs/SYNC-PROTOCOL.md) | Zeit- und Party-Synchronisation |
 | [docs/ROADMAP.md](docs/ROADMAP.md) | Umsetzungsphasen |
@@ -33,44 +35,50 @@ Detaildokumente konkretisieren das Konzept, dürfen ihm aber nicht widersprechen
 ## Das Produkt in 60 Sekunden
 
 1. **Charakter erstellen.** Mensch, Elf, Zwerg, Goblin oder Ork. Keine Klassen, keine Stats, keine Geschlechtsauswahl. Die Figur ist Identität, kein Build.
-2. **Im Lager ankommen.** Das Lager ist Home-Screen und Navigation: Abenteuerbuch, Rucksack, Sammlung, Signalhorn und Händler sind Teil der Welt.
-3. **Quest wählen.** 15, 25 oder 50 Minuten; später epische Abenteuer als 3×25-Minuten-Bogen. Die Quest ist die Timer-Konfiguration.
-4. **Fokussieren.** Der Charakter reist automatisch durch eine 2D-Fantasywelt. Der Timer bleibt lesbar in die Welt integriert. Während Fokus ist keine Spielinteraktion nötig.
-5. **Ankommen und rasten.** XP und Gold werden vergeben, eine Truhe wird verdient. Erst kommt die reale Pause, danach darf die Truhe geöffnet werden.
-6. **Welt wachsen lassen.** Loot ist kosmetisch und ohne Duplikate. Gold gibt Wahlfreiheit beim Händler. Sets, Erinnerungen, Begleiter und Lagerentwicklung erzählen langfristig die Geschichte investierter Fokuszeit.
-7. **Optional gemeinsam aufbrechen.** Solo ist vollständig. Party-Einladung erfolgt bevorzugt per Link, ein kurzer Code bleibt Fallback. Alle bestätigen Bereitschaft, sehen dieselbe Uhr und arbeiten dann „zusammen allein“ – ohne Chat oder Pings während Fokus.
-
-### Leitplanken
-
-- **Die Welt ist das Menü.**
-- **Fokus vor Gamification.**
-- **1 Fokusminute = 1 XP.**
-- **Keine Streaks, Daily Rewards, FOMO oder Schuldmechaniken.**
-- **Keine Power-Progression.**
-- **Keine Party-Truhe oder sozialen Leistungsrankings.**
-- **Accessibility verändert nie Rewards.**
-- **Die Fokuszeit der Person ist heiliger als die Spielinszenierung.**
+2. **Im Lager ankommen.** Das Lager ist Heimat, Navigation und sichtbare Geschichte. Das Abenteuerbuch startet Quests, das Signalhorn verbindet Gefährten, der Händler bringt Kosmetik.
+3. **Quest wählen.** Kundschaftergang 15, kurze Quest 25, mittlere Quest 50. Epische Abenteuer kommen später als 3×25-Minuten-Bogen.
+4. **Fokussieren.** Während real gearbeitet wird, reist die Figur automatisch durch eine ruhige 2D-Fantasywelt. Keine Interaktion ist nötig.
+5. **Abschließen und rasten.** Fokuszeit gibt XP, eine abgeschlossene Quest Gold und eine Truhe. Die Rast kommt **vor** der Truhenöffnung.
+6. **Welt wachsen lassen.** Neue Looks, Relikte, Sets, Lagerobjekte und später Begleiter erzählen die investierte Zeit weiter.
+7. **Optional gemeinsam.** Solo ist vollständig. Später ermöglicht das Signalhorn synchronen Gruppenfokus ohne Chat, Dungeon Master oder Leistungsranking.
 
 ---
 
-## Fokuszeiten und Economy
+## Produktregeln
 
-| Quest | Fokus | Basisgold |
-|---|---:|---:|
-| Kundschaftergang | 15 min | 3 |
-| Kurze Quest | 25 min | 5 |
-| Mittlere Quest | 50 min | 10 |
-| Episches Abenteuer | 3 × 25 min | 15 gesamt |
-
-XP entstehen pro tatsächlich fokussierter Minute. Bei vorzeitigem Abbruch bleiben diese XP erhalten; Questabschluss-Gold und Truhe gibt es nur für einen abgeschlossenen Fokusabschnitt.
-
-Loot nutzt vier Seltenheitsstufen: **Gewöhnlich 60 % · Ungewöhnlich 27 % · Selten 11 % · Außergewöhnlich 2 %**. Wenn eine Truhe ein Item enthält, ist es neu.
+- **1 fokussierte Minute = 1 XP**
+- Gold: **1 pro 5 erfolgreich abgeschlossenen Fokusminuten**
+- Loot ist kosmetisch und hat **keine Duplikate**
+- vier Seltenheiten: **60 / 27 / 11 / 2 %**
+- keine Streak-Pflicht, Daily Rewards, Countdown-Shops oder Produktivitätsrankings
+- Accessibility-Einstellungen verändern niemals Rewards
+- Abwesenheit wird niemals bestraft
 
 ---
 
-## Aktueller Content und vorhandene Logik
+## Vertical Slice zuerst
 
-Das Repository enthält bereits einen umfangreichen Content- und Logikbestand, darunter Quest-/Regionsdaten, Itemkataloge, Lootlogik und zeitbasierte Journey-Logik. Bestehender Content darf weiterverwendet werden, sofern er Concept V2 entspricht; widersprechende Texte, Tests und Annahmen werden schrittweise migriert.
+Die erste Umsetzung beweist den kompletten emotionalen Kern mit nur einem Weg:
+
+**Waldintro → Account → Charakter → kleines Lager → „Ein Licht im Unterholz“ → 15 Minuten Fokus → Questabschluss → Rast → erste Truhe → Alte Weglaterne erscheint im Lager.**
+
+Erst wenn dieser Weg visuell, akustisch und funktional trägt, wird auf weitere Regionen, Quests und Langzeitsysteme skaliert.
+
+---
+
+## Bestehender Content & Core
+
+Im Repository liegen bereits Quest-, Regionen-, Item- und Timerbausteine. Sie sind wertvolles Material, aber nicht automatisch verbindliche Produktlogik. Wo bestehender Content oder Code Concept V2 widerspricht, wird er schrittweise migriert statt das Konzept zurückzubiegen.
+
+Besonders wiederverwendbar sind:
+
+- `content/quests.de.json`
+- `content/regions.de.json`
+- `content/items.de.json`
+- `lib/quests/`
+- `lib/loot/`
+- `lib/timer/journey.ts`
+- `docs/SYNC-PROTOCOL.md`
 
 ```bash
 npm test
@@ -79,22 +87,15 @@ npm run typecheck
 
 ---
 
-## Umsetzungsreihenfolge
+## Entwicklungsprinzip
 
-1. **Vertical Slice:** Einstieg → Account → Charakter → Lager → „Ein Licht im Unterholz“ → 15 Minuten Fokus → Abschluss → Rast → deterministische Weglaterne.
-2. **Core MVP:** 15/25/50-Quests, Progression, Loot, Ausrüstung, erste Lagerentwicklung, Settings, responsive Nutzung.
-3. **Weltvertiefung:** Händler, Sets, Begleiter, weitere Regionen und Lagerstufen.
-4. **Party:** Signalhorn, Einladungslink + Code-Fallback, Ready Check, gemeinsame Uhr, individuelle Rewards.
-5. **Epische Abenteuer:** 3×25 Minuten mit persistentem Aktfortschritt.
-6. **Langfristige Welt:** weitere Inhalte, Events und Plattformoptionen.
+**So einfach wie technisch möglich, so immersiv wie gestalterisch nötig.**
+
+Keine Game Engine, kein komplexes RPG und kein Feature um seiner selbst willen. Die technische Priorität ist Zuverlässigkeit, Synchronisation, schnelle Ladezeit, Accessibility und eine störungsfreie Fokusphase.
+
+> **Die Fokuszeit der Person ist heiliger als die Spielinszenierung.**
 
 ---
-
-## Für Mitwirkende
-
-Vor Produktentscheidungen zuerst [docs/CONCEPT.md](docs/CONCEPT.md) lesen. Bei einem Widerspruch zwischen älteren Dokumenten und Concept V2 gilt Concept V2; der Widerspruch soll im selben Change bereinigt oder explizit als Migration dokumentiert werden.
-
-Details zum Entwicklungsworkflow: [CONTRIBUTING.md](CONTRIBUTING.md) · [docs/WORKFLOW.md](docs/WORKFLOW.md)
 
 ## Lizenz
 

--- a/docs/ART-DIRECTION.md
+++ b/docs/ART-DIRECTION.md
@@ -1,76 +1,200 @@
-# Kunstrichtung
+# Art Direction
 
-> Zuständigkeit: `#junDev` · Ergänzt [DESIGN-SYSTEM.md](DESIGN-SYSTEM.md), ersetzt es nicht.
+> Status: verbindlich · ergänzt [CONCEPT.md](CONCEPT.md), [DESIGN-SYSTEM.md](DESIGN-SYSTEM.md) und [ASSET-BIBLE.md](ASSET-BIBLE.md).
 
-## Die Grenze
+## Leitidee
 
-Zwei Welten, und die Grenze zwischen ihnen wird **scharf** gezogen — nicht weich.
-Ein Verlauf zwischen den beiden ist genau der Punkt, an dem so ein Hybrid nach zwei
-Projekten aussieht.
+> **Ein illustriertes Fantasy-Abenteuerbuch, dessen Seiten lebendig geworden sind.**
 
-| | Bedienoberfläche | Gegenstände und Kulisse |
-|---|---|---|
-| **Was** | Knöpfe, Felder, Timer, Listen, Navigation, Klassen-Sigel | Items, Truhen, Wanderungs-Kulisse, Regionen |
-| **Wie** | Gezeichnete SVG-Linie, 1,5&nbsp;px, runde Enden | Illustriert, mit Fläche und Tonwert |
-| **Farbe** | Ausschließlich Tokens | Eigene, gedeckte Palette in der Nähe der Tokens |
-| **Wo** | überall | **nur innerhalb eines Rahmens** |
+Die Anwendung ist eine **2D-illustrierte Adult-Cozy-Fantasy-Welt mit Pen-&-Paper-Seele**. Sie darf warm, geheimnisvoll und detailreich sein, aber nie kindlich, hektisch oder wie ein Mobile-RPG wirken.
 
-**Die Regel, die den Hybrid trägt:** Illustration erscheint nie frei auf der Fläche.
-Sie sitzt immer in einem klar begrenzten Feld — der Item-Kachel, dem Truhen-Podest, dem
-Wanderungs-Band. Außerhalb dieser Felder gibt es ausschließlich Linie. Damit liest sich
-die Illustration als *Abbildung eines Gegenstands*, nicht als Dekoration der Oberfläche.
+Nicht gewollt:
+- Chibi-/Kawaii-Proportionen
+- fotorealistische Dark Fantasy
+- neonfarbene Mobile-Game-Raritätsästhetik
+- SaaS-Dashboards mit aufgeklebten Fantasytexturen
+- UI, die wichtiger wirkt als die Welt
 
-## Gegenstände: ein Baukasten, keine 576 Zeichnungen
+---
 
-576 unterscheidbare Gegenstände entstehen aus **26 gezeichneten Teilen**:
+## Welt zuerst, UI danach
 
-```
-12 Grundformen  ×  6 Materialien  ×  8 Embleme  =  576
-```
+**Die Welt ist das Menü.** Das Lager ist nicht Illustration hinter einer Navigation, sondern die eigentliche Bühne für Navigation.
 
-| | |
-|---|---|
-| **Grundformen** | Klinge · Kelch · Ring · Foliant · Mantel · Laterne · Krone · Schlüssel · Amulett · Stab · Maske · Horn |
-| **Materialien** | Eisen · Bronze · Silber · Mondstein · Glut · Obsidian |
-| **Embleme** | Auge · Flamme · Welle · Wurzel · Stern · Spirale · Schwinge · Riss |
+Diegetische Elemente wie Abenteuerbuch, Signalhorn, Rucksack, Sammlung und Händler sind visuell Teil der Szene. Technisch bleiben sie semantische, zugängliche Bedienelemente.
 
-Das Aussehen ist **deterministisch aus der Item-Kennung** abgeleitet — dieselbe Kennung
-ergibt auf jedem Gerät und in jeder Sitzung denselben Gegenstand. Es wird nichts
-gewürfelt und nichts gespeichert außer der Kennung.
+Fantasy-Metaphern dürfen niemals Bedienbarkeit verschlechtern. Einstellungen dürfen ein konventionelles Zahnrad sein; ein Zurück-Button darf wie ein Zurück-Button funktionieren.
 
-Der Name entsteht mit: `Mondsteinlaterne der Schwinge`, `Glutklinge des Risses`.
-Deutsche Komposita tragen das erstaunlich weit.
+---
 
-### Wie der Hybrid hier greift
+## Perspektive
 
-Jeder Gegenstand hat ein optionales Feld `art`. Ist es leer, rendert der Baukasten eine
-Liniengrafik — vollwertig, auf System, sofort verfügbar. Ist es gesetzt, ersetzt die
-Illustration sie.
+Lager und zentrale World-Screens nutzen eine leicht erhöhte diagonale **2.5D-/Diorama-Perspektive aus 2D-Art**.
 
-Das ist kein Platzhalter-Kompromiss, sondern die Reihenfolge, in der man so etwas baut:
-**Der Baukasten geht zuerst live, die Illustrationen kommen Stück für Stück dazu** —
-priorisiert nach Seltenheit. Eine legendäre Krone wird zuerst illustriert, ein
-gewöhnlicher Wachsstummel vielleicht nie. Kein Screen wartet auf eine Zeichnung.
+Kein echtes 3D, kein City-Builder-Topdown.
 
-## Wanderungs-Kulisse
+Tiefe entsteht durch:
+- Layer
+- Überlagerung
+- Größenunterschiede
+- Licht
+- Schatten
+- atmosphärische Perspektive
+- sehr zurückhaltende Parallax-Bewegung
 
-Drei SVG-Ebenen mit unterschiedlicher Geschwindigkeit — Horizont, Mittelgrund, Weg —
-plus die Gruppe als Sigel-Reihe darauf. Bewegt wird ausschließlich mit
-`transform: translateX`, gesteuert vom Quest-Fortschritt.
+Desktop darf breiter und panoramischer sein; Mobile wird neu komponiert statt nur verkleinert.
 
-Acht Regionen, je eine Kulisse. Welche Region gezeigt wird, bestimmt die Quest.
+---
 
-**Für die Kulissen — und nur für sie — sind generierte Hintergründe vorgesehen.**
-Sie sind großflächig, tonwertig und tragen keine Bedeutung; dort fällt eine
-Ungenauigkeit nicht auf. Für Item-Icons gilt das ausdrücklich **nicht**: 576 einzeln
-generierte Gegenstände würden nie zueinander passen, und Seltenheit muss man erkennen,
-nicht erahnen.
+## Farbwelt
 
-## Was nicht passiert
+### Außenwelt
+Tiefe, gedeckte Farben:
+- Nachtblau
+- Waldgrün
+- Nebelgrau
+- dunkles Violett
+- Moos
+- Erde
+- Stein
 
-| Nicht | Warum |
-|---|---|
-| Pixel-Art neben Linien-Icons | Zwei Rasterlogiken auf einem Screen sehen nach zwei Projekten aus |
-| Illustration in der Navigation | Die Grenze verwischt, der Hybrid fällt auseinander |
-| Generierte Item-Icons | Seltenheit muss erkennbar sein, nicht ahnbar |
-| Bewegte Kulisse während der Rast | Die Rast ist der Ort, an dem nichts wandert |
+### Lager
+Warme Gegengewichte:
+- Feuerlicht
+- Bernstein
+- Messing
+- dunkles Holz
+- Leder
+- warmes Pergament
+- Kerzenlicht
+
+Licht übernimmt einen Teil der UX-Hierarchie. Interessante Orte dürfen durch warmes Licht, Reflexion oder kleine atmosphärische Veränderungen geführt werden statt durch rote Badges und Tutorial-Pfeile.
+
+---
+
+## Materialien
+
+Die Welt fühlt sich handgemacht und benutzt an:
+
+**Pergament · Holz · Leder · Stoff · patiniertes Metall · Stein · Tinte**
+
+Ornamentik bleibt zurückhaltend. Nicht jeder Button braucht Goldrand, Runen und Schwerter.
+
+---
+
+## Typografie
+
+Zwei Rollen:
+
+### Narrativ
+Charaktervolle buchartige Serifenschrift für Questnamen, Überschriften und kurze Erzählertexte.
+
+### Funktional
+Sehr gut lesbare Schrift für Timer, Zahlen, Einstellungen, längere Texte und Accessibility-Informationen.
+
+Lesbarkeit steht immer über Atmosphäre.
+
+---
+
+## Charaktere
+
+Stilisierte 2D-Fantasyfiguren, nicht chibi. Köpfe dürfen leicht größer als realistisch sein, damit Gesichter, Haare und Kosmetik bei kleiner Darstellung lesbar bleiben.
+
+Silhouetten sollen die fünf Völker unterscheiden:
+- Mensch: vielseitig, bodenständig
+- Elf: elegant, naturverbunden
+- Zwerg: kompakt, geerdet, gemütlich
+- Goblin: klein, neugierig, expressiv
+- Ork: kräftig, warm, Richtung „sanfter Riese“
+
+Diese Merkmale sind visuelle Tendenzen, keine Persönlichkeitsvorgaben.
+
+---
+
+## Quest- und Regionenbilder
+
+Jede Region besitzt eine erkennbare Identität über:
+- Licht
+- Vegetation
+- Wetter
+- Landschaft
+- Architektur
+- Farbtemperatur
+- regionale Requisiten
+
+Questbilder werden soweit sinnvoll **modular aus Ebenen** gebaut. Nicht jede Quest benötigt ein vollständig neues Gemälde. Ein Regionshintergrund kann mit unterschiedlichen Vordergründen, Lichtzuständen, Wetter- und Questdetails mehrere Geschichten tragen.
+
+Produktionsdetails stehen in [ASSET-BIBLE.md](ASSET-BIBLE.md).
+
+---
+
+## UI & Icons
+
+Icons dürfen leicht handgezeichnet bzw. graviert wirken, müssen aber auch klein eindeutig bleiben.
+
+Funktionale Standards bleiben Standards. Ein Lautsprecher, Zahnrad oder Zurück-Pfeil muss nicht durch eine komplizierte Fantasy-Metapher ersetzt werden.
+
+Overlays werden sparsam verwendet. Der Screen soll zuerst als Welt und erst danach als Interface gelesen werden.
+
+---
+
+## Rarität
+
+Rarität wird ruhig inszeniert. Die vier Stufen dürfen eigene Akzentfarben und Material-/Lichtintensitäten haben, aber keine Neonränder, dauernden Partikel oder Slotmachine-Ästhetik.
+
+Rarität wird nie ausschließlich durch Farbe kommuniziert.
+
+---
+
+## Motion
+
+Leitbild: **lebendes Bilderbuch**.
+
+Ambient Motion:
+- Feuer
+- Blätter
+- Rauch
+- Stoff
+- Haare
+- Atmung
+- Licht
+- Nebel
+
+Motion belohnt einen Blick, fordert ihn aber nicht ein.
+
+Stärkere Bewegung bleibt für Aufbruch, Questabschluss, Truhe, Level-Meilenstein, Lagerentwicklung und Begleiter reserviert.
+
+Während Fokus bleibt alles langsam und zurückhaltend. Keine hektischen Kämpfe, kein permanentes Pulsieren, keine Partikelüberladung.
+
+Reduced Motion erhält gleichwertige statische/Fade-basierte Zustände.
+
+---
+
+## Audio
+
+Audio ist ein Teil der Identität, aber nie Voraussetzung.
+
+- Camp: warme Musik + Ambiente
+- Fokus: Abenteuer, Natur, Lagerfeuer/Ambiente oder Stille
+- Aufbruch: wiederkehrendes ca. 3-Sekunden-Motiv
+- Questabschluss: musikalische Auflösung statt Standard-Beep
+- Rast: Musik deutlich reduzieren, Umgebung stehen lassen
+- Truhe: Holz, Metall, Verschluss, kurzer Fundakzent – kein Glücksspielklang
+
+Musik, Umgebung und Effekte sind getrennt regelbar.
+
+Die Produktionsanforderungen und das erste konkrete Assetpaket stehen in [ASSET-BIBLE.md](ASSET-BIBLE.md).
+
+---
+
+## Art-Direction-Prüffragen
+
+Vor Freigabe jedes Assets:
+
+> **Könnte dieses Element eine Seite unseres lebendig gewordenen Abenteuerbuchs sein?**
+
+und
+
+> **Hilft es der Atmosphäre, ohne um Aufmerksamkeit zu kämpfen?**
+
+Wenn eine der Antworten Nein ist, wird das Asset überarbeitet.

--- a/docs/ASSET-BIBLE.md
+++ b/docs/ASSET-BIBLE.md
@@ -1,0 +1,489 @@
+# Asset Bible
+
+> Status: **verbindliche Produktionsleitlinie** · Stand 2026-09-04
+>
+> Gilt zusammen mit [CONCEPT.md](CONCEPT.md), [ART-DIRECTION.md](ART-DIRECTION.md), [DESIGN-SYSTEM.md](DESIGN-SYSTEM.md) und [MOTION-ENGINE.md](MOTION-ENGINE.md).
+>
+> Ziel: Assets so produzieren, dass Illustration, Animation und Audio wie **eine Welt** wirken und von der Anwendung modular, performant und barrierearm genutzt werden können.
+
+---
+
+## 1. Produktionsprinzip
+
+Wir bauen **kein Spiel aus Einzelbildern**, sondern ein kleines wiederverwendbares Asset-System.
+
+Die visuelle Leitidee bleibt:
+
+> **Ein illustriertes Fantasy-Abenteuerbuch, dessen Seiten lebendig geworden sind.**
+
+Ein Screen wird soweit sinnvoll aus Ebenen zusammengesetzt:
+
+1. Hintergrund
+2. Mittelgrund
+3. Vordergrund
+4. Charakter(e)
+5. atmosphärische Overlays (Nebel, Licht, Blätter, Glut)
+6. semantische UI
+
+Bewegung entsteht überwiegend durch CSS/SVG/`motion` und zeitabhängige Zustände. Video ist kein Standardformat.
+
+---
+
+## 2. Asset-Kategorien
+
+### 2.1 World Art
+- Lager
+- Regionen
+- Quest-Szenen
+- Übergangsszenen
+- Rast
+- besondere Meilensteine
+
+### 2.2 Characters
+- fünf Völker
+- modulare Körper-/Silhouettenvarianten
+- Haare und Haarfarben
+- Ausrüstungsslots
+- Idle-Posen
+
+### 2.3 Items & Camp Props
+- kosmetische Ausrüstung
+- Relikte / Sets
+- Lagerobjekte
+- Händlerware
+- Begleiter
+
+### 2.4 UI Art
+- Abenteuerbuch
+- Rahmen / Paneele
+- Icons
+- Ornamente
+- Karten- und Pergamentelemente
+
+### 2.5 Motion Assets
+- Aufbruch
+- Questabschluss
+- Truhe
+- Level-Meilenstein
+- Begleiter-Schlüpfen
+- einzelne Ambient-Loops
+
+### 2.6 Audio
+- Musik
+- Umgebung
+- UI-/World-SFX
+- Aufbruch-/Abschlussmotiv
+
+---
+
+## 3. Vertical-Slice-Assetpaket
+
+Bevor weitere Regionen produziert werden, muss **ein vollständiges visuelles Referenzpaket** existieren.
+
+Der Vertical Slice umfasst:
+
+**Intro → Charakter → Startlager → „Ein Licht im Unterholz“ → Fokus → Rast → Truhe → Weglaterne im Lager**
+
+Dieses Paket definiert den Qualitätsstandard für alles Weitere.
+
+### 3.1 Benötigte Visual Assets
+
+#### Intro / Wald
+- `intro-forest-bg`
+- `intro-forest-mid`
+- `intro-forest-fg`
+- `intro-camp-glow`
+- optional: Nebel-/Partikelmaske
+
+#### Startlager
+- `camp-stage-01-bg`
+- `camp-stage-01-mid`
+- `camp-stage-01-fg`
+- `camp-fire`
+- `camp-tent-01`
+- `camp-adventure-book`
+- `camp-backpack`
+- `camp-signal-horn`
+- `camp-lantern-slot-empty`
+- `camp-lantern-old-road`
+
+#### Erste Quest „Ein Licht im Unterholz“
+Vier Journey-Beats für die 15-Minuten-Quest:
+1. Waldrand / Aufbruch
+2. tieferer Wald
+3. Licht zwischen den Bäumen
+4. Fundort / Ziel
+
+Jeder Beat muss als responsive Szene funktionieren und dieselbe Region erkennbar behalten.
+
+#### Rast
+- ruhiger Feuerplatz
+- Character-rest pose
+- optionale Holzscheit-Interaktion
+
+#### Erste Truhe
+- geschlossene Truhe
+- geöffnete Truhe
+- Licht-/Glanzmaske
+- Reduced-Motion-Endzustand
+
+#### Erster Fund
+- `item-old-road-lantern`
+- Darstellung als Fundstück
+- Darstellung als Lagerobjekt
+
+### 3.2 Charakter-Referenz
+
+Für den Vertical Slice wird zunächst **ein vollständig ausgearbeiteter Referenzcharakter** benötigt. Die übrigen Völker werden erst danach final produziert.
+
+Referenzset:
+- Front-/3/4-Ansicht
+- Camp Idle
+- Walk/Departure Pose
+- Focus-Journey Pose
+- Rest Pose
+- Return Pose
+
+Erst wenn Stil, Proportionen und Layering funktionieren, wird auf Mensch, Elf, Zwerg, Goblin und Ork skaliert.
+
+---
+
+## 4. Bildformate und technische Vorgaben
+
+### 4.1 Rasterillustrationen
+Bevorzugt **WebP** oder **AVIF** für große Hintergründe. PNG nur bei echter Transparenzanforderung.
+
+Master-Dateien dürfen höher aufgelöst sein; ausgelieferte Webassets werden optimiert.
+
+### 4.2 Vektoren
+**SVG** für:
+- Icons
+- UI-Linien
+- einfache Props
+- Masken
+- dekorative Shapes
+- animierbare geometrische Elemente
+
+### 4.3 Keine Textinhalte im Bild
+Questnamen, Timer, Buttons und erzählerischer Text werden **nie in die Illustration eingebrannt**. Texte bleiben HTML, damit sie responsiv, übersetzbar und zugänglich sind.
+
+### 4.4 Transparenz
+Transparente Charakter-/Prop-Layer bekommen ausreichend Rand, damit Idle-Bewegungen nicht abgeschnitten werden.
+
+### 4.5 Farbraum
+sRGB für Webausgabe.
+
+---
+
+## 5. Responsive Komposition
+
+Desktop und Mobile nutzen dieselbe Welt, aber nicht zwingend denselben Zuschnitt.
+
+Für zentrale Szenen werden mindestens zwei Kompositionsvarianten geplant:
+
+- **Landscape:** 16:9 bzw. breite Desktop-Komposition
+- **Portrait:** 9:16 bzw. mobile Komposition
+
+Wo möglich werden Ebenen statt zwei komplett unterschiedlicher Bilder verwendet. Der Code darf Position, Skalierung und Cropping der Layer pro Breakpoint verändern.
+
+### Safe Zones
+Keine narrativ wichtigen Details in äußerste 10 % der Bildränder legen. Timer-/Textzone muss vorab definiert sein.
+
+---
+
+## 6. Layer-Konvention für Quest-Szenen
+
+Eine Region kann aus wiederverwendbaren Layern bestehen:
+
+```text
+regions/
+  whispering-forest/
+    background.webp
+    midground.webp
+    foreground.webp
+    fog.webp
+    light-mask.webp
+    beats/
+      scout-light-01.webp
+      scout-light-02.webp
+      scout-light-03.webp
+      scout-light-04.webp
+```
+
+Nicht jede Quest braucht vier komplett neue Vollbilder. Bevorzugt werden:
+- gemeinsamer Region-Hintergrund
+- austauschbare Mittel-/Vordergründe
+- questbezogene Detail-Layer
+- Licht-/Wetterzustände
+
+So können viele Quests aus wenigen hochwertigen Bausteinen entstehen.
+
+---
+
+## 7. Charakter-Layering
+
+Charaktere müssen kosmetische Ausrüstung ermöglichen.
+
+Empfohlene Renderreihenfolge:
+
+```text
+back-item
+body
+legs
+shoes
+upper-body
+hair-back
+head
+face
+hair-front
+head-item
+hand-item
+accessory
+foreground-effect
+```
+
+Alle Völker verwenden dieselben logischen Slots. Ein Item kann pro Volk eine angepasste Transform-/Anchor-Konfiguration bekommen.
+
+### Wichtig
+Nicht sofort den gesamten Itemkatalog illustrieren. Zuerst Körper, Silhouetten und wenige repräsentative Gegenstände stabilisieren.
+
+---
+
+## 8. Motion-System
+
+### 8.1 Ambient Motion
+Beispiele:
+- Feuerflackern
+- Rauch
+- Blätter
+- Nebel
+- Stoff
+- Haare
+- Atmung
+- Lichtpuls
+
+Diese Bewegungen sind langsam, klein und unterbrechbar.
+
+### 8.2 Journey Motion
+Die Reise folgt der Fokuszeit. Szenenwechsel werden aus dem Questfortschritt abgeleitet, nicht von einem eigenen Timer.
+
+### 8.3 Hero Motion
+Stärkere Animation ist reserviert für:
+- Aufbruch
+- Questabschluss
+- Truhe
+- Level-Meilenstein
+- Lagerentwicklung
+- Begleiter erscheint
+
+### 8.4 Reduced Motion
+Für jede Hero-Animation muss vor Produktionsfreigabe ein statischer bzw. Fade-basierter Reduced-Motion-Endzustand definiert sein.
+
+### 8.5 Formatwahl
+- CSS / `motion`: UI, Fades, leichte Transforms
+- SVG: einfache animierte World-/UI-Elemente
+- Rive: nur dort, wo echte State-Machine-Animation einen Mehrwert hat
+- Video: Ausnahme, nicht Standard
+
+---
+
+## 9. Truhenanimation
+
+Die Truhe ist ein hochwertiger, aber **nicht casinoartiger** Moment.
+
+Ablauf:
+1. Truhe setzt sich / kurzer Materialimpuls
+2. Verschluss öffnet
+3. Deckel bewegt sich
+4. warmes Licht tritt aus
+5. Gegenstand wird präsentiert
+6. UI blendet Fundinformationen ein
+
+Keine Slotmachine-Sounds, kein Near-Miss, keine blinkenden Jackpotfarben.
+
+Die vier Seltenheiten verändern nur Intensität, Materialakzent und Inszenierung – nicht die Dauer drastisch.
+
+---
+
+## 10. Audio-Bible
+
+### 10.1 Grundsatz
+Audio trägt Identität, ist aber niemals für Bedienung erforderlich.
+
+### 10.2 Startpaket Musik
+Für den Vertical Slice reichen zunächst:
+1. **Camp Theme** – warm, ruhig, 3–6 min nahtlos loopbar
+2. **Adventure Focus Theme** – zurückhaltend, 5–10 min loopbar
+3. **Rest Ambience** – primär Umgebung, kaum Musik
+4. **Departure Motif** – ca. 3 s
+5. **Arrival / Completion Resolve** – ca. 3–5 s, musikalisch verwandt mit Departure
+
+### 10.3 Startpaket Umgebung
+- Lagerfeuer
+- Nachtwald
+- leichter Wind
+- Blätter
+- optional Eule / ferne Naturereignisse, sehr sparsam
+
+### 10.4 Startpaket Effekte
+- Buch öffnen / Seite
+- Button / Auswahl sehr dezent
+- Schritte / Ausrüstung beim Aufbruch
+- Holzscheit
+- Truhenverschluss
+- Truhendeckel
+- Item-Fund
+- Gold
+- Level-up später
+
+### 10.5 Audio-Qualität
+- keine abrupten Loop-Nähte
+- keine dominanten Peaks während Fokus
+- kein permanentes hochfrequentes Glitzern
+- Lautheit zwischen Tracks konsistent
+- Musik, Umgebung und Effekte getrennt steuerbar
+
+### 10.6 Formate
+Webauslieferung bevorzugt Opus/WebM oder AAC/M4A je Browserstrategie; Produktionsmaster verlustfrei archivieren (z. B. WAV).
+
+### 10.7 Rechte
+Jedes externe oder beauftragte Audioasset braucht dokumentierte Nutzungsrechte. Keine zufälligen YouTube-/Streaming-/Game-Tracks in Produktbuilds.
+
+---
+
+## 11. Asset Naming
+
+Dateinamen: englisch, lowercase, kebab-case, ohne Leerzeichen.
+
+Schema:
+
+```text
+<domain>-<context>-<name>-<variant>.<ext>
+```
+
+Beispiele:
+- `camp-stage-01-background.webp`
+- `camp-stage-01-fire.svg`
+- `region-whispering-forest-background.webp`
+- `quest-light-undergrowth-beat-02.webp`
+- `character-goblin-hair-03.svg`
+- `item-old-road-lantern.webp`
+- `audio-camp-theme-01.ogg`
+- `sfx-chest-latch-01.ogg`
+
+---
+
+## 12. Ordnerstruktur
+
+Zielstruktur für auslieferbare Assets:
+
+```text
+public/
+  assets/
+    world/
+      intro/
+      camp/
+      regions/
+      quests/
+    characters/
+      human/
+      elf/
+      dwarf/
+      goblin/
+      orc/
+      equipment/
+    items/
+    companions/
+    ui/
+      icons/
+      frames/
+      ornaments/
+    motion/
+    audio/
+      music/
+      ambience/
+      sfx/
+```
+
+Quell-/Masterdateien gehören nicht zwingend in `public/`. Falls sie im Repo versioniert werden, liegen sie getrennt unter `design/source/` oder werden über ein klar benanntes externes Design-Repository/Storage verwaltet.
+
+---
+
+## 13. Asset Manifest
+
+Assets werden nicht überall als freie Pfade in Komponenten verteilt. Spätestens mit dem Vertical Slice wird ein typisiertes Manifest eingeführt.
+
+Beispiel:
+
+```ts
+export const assets = {
+  camp: {
+    stage01: {
+      background: '/assets/world/camp/stage-01/background.webp',
+      fire: '/assets/world/camp/stage-01/fire.svg',
+    },
+  },
+} as const
+```
+
+Ziel:
+- fehlende Assets früh erkennen
+- Preloading gezielt steuern
+- Varianten pro Breakpoint/Reduced Motion sauber abbilden
+- spätere CDN-Migration vereinfachen
+
+---
+
+## 14. Performance-Budgets
+
+Assets werden nach Nutzung priorisiert geladen.
+
+### Initiale Seite
+Intro/Lager soll auf typischer Verbindung schnell sichtbar werden. Große Hintergrundassets werden komprimiert und responsive ausgeliefert.
+
+### Quest
+Nur die aktuelle Region plus nächster Journey-Beat wird priorisiert. Spätere Beats werden während des laufenden Fokusblocks nachgeladen.
+
+### Audio
+Musik wird erst nach Nutzerinteraktion gestartet und bei Bedarf geladen. Keine komplette Audio-Bibliothek beim ersten Besuch.
+
+### Hero Motion
+Rive oder vergleichbare Runtime niemals in den initialen Bundle-Pfad zwingen, wenn sie erst später benötigt wird.
+
+---
+
+## 15. Qualitätscheck pro Asset
+
+Ein Asset ist erst freigegeben, wenn folgende Fragen mit Ja beantwortet werden können:
+
+- Sieht es nach derselben Welt wie unser Referenzlager aus?
+- Passt es zur Adult-Cozy-Fantasy-Richtung?
+- Ist es ruhig genug für eine Fokus-App?
+- Funktioniert es in Desktop und Mobile?
+- Sind wichtige Informationen nicht im Bild eingebrannt?
+- Funktioniert die Szene ohne Animation?
+- Gibt es bei wichtiger Animation einen Reduced-Motion-Zustand?
+- Ist die Datei sinnvoll optimiert?
+- Sind Nutzungsrechte geklärt?
+- Ist der Dateiname und Speicherort konform?
+
+---
+
+## 16. Produktionsreihenfolge
+
+**Nicht zuerst 11 Regionen produzieren.**
+
+Verbindliche Reihenfolge:
+
+1. Style Frames für Intro, Lager, Charakter und erste Quest
+2. einen Referenzcharakter finalisieren
+3. Startlager finalisieren
+4. „Ein Licht im Unterholz“ mit vier Journey-Beats finalisieren
+5. Rast finalisieren
+6. erste Truhe + Weglaterne finalisieren
+7. Departure-/Completion-Audio finalisieren
+8. Camp-/Focus-Audio finalisieren
+9. alles im Vertical Slice integrieren
+10. erst nach visueller Abnahme auf weitere Völker, Regionen und Loot skalieren
+
+Das Vertical-Slice-Paket ist die **visuelle Definition of Done** für die Welt.

--- a/docs/CONCEPT.md
+++ b/docs/CONCEPT.md
@@ -1,163 +1,425 @@
-# Spielkonzept
+# Concept V2
 
-> Status: **Draft** · Änderungen brauchen ein Issue mit `#SENDEV` und einen ADR-Eintrag.
+> Status: **verbindliche Produktspezifikation** · Stand 2026-09-04
+>
+> Dieses Dokument ist die Source of Truth für **Was** und **Warum** des Produkts. Detailumsetzung liegt in `SCREENS.md`, `DESIGN-SYSTEM.md`, `ART-DIRECTION.md`, `ARCHITECTURE.md` und `SYNC-PROTOCOL.md`.
 
-## Leitgedanke
+## 1. Vision & Produktstrategie
 
-Ein Pomodoro-Timer scheitert selten an der Technik, sondern daran, dass niemand ihn
-benutzt. Die Gamification hier ist deshalb kein Anstrich, sondern übernimmt zwei
-konkrete Aufgaben:
+Das Produkt ist eine gamifizierte Fokus-Anwendung in einer lebendigen Cozy-Fantasy-Welt. Reale Fokuszeit treibt die virtuelle Reise voran: Nutzer wählen keine abstrakte Timerdauer, sondern eine Quest. Während sie im echten Leben konzentriert arbeiten, reist ihr Charakter automatisch durch eine Fantasywelt. Nach erfolgreichem Fokus kehrt er mit Erfahrung, Gold, Geschichten und gelegentlichen Fundstücken zurück.
 
-1. **Sie macht die Timer-Konfiguration zu einer Entscheidung mit Bedeutung.**
-   Niemand stellt gerne Minuten in einem Formular ein. Aber eine Quest wählt man gern —
-   und die Quest bringt ihre Dauer mit.
-2. **Sie gibt der Pause einen Grund.** Der häufigste Fehler beim Pomodoro ist, die
-   Pause zu überspringen. Wenn die Pause "Rast" heißt und der Charakter dort etwas
-   regeneriert, wird das Überspringen zu einer sichtbaren Entscheidung.
+**One-Liner:** Arbeit wird zum Abenteuer: Wähle eine Quest, fokussiere dich und lass mit deiner echten Zeit eine persönliche Fantasywelt wachsen.
 
-**Anti-Ziel:** Kein Zwang, keine Streak-Angst, keine Dark Patterns. Wer eine Quest
-abbricht, verliert nichts Aufgebautes — er bekommt nur diese eine Truhe nicht.
+### Zielgruppe
+Menschen, denen Anfangen, Strukturieren oder längeres Fokussieren schwerfällt und für die klassische Produktivitätsanwendungen zu nüchtern oder druckorientiert sind. Fantasy-, Pen-&-Paper-, Gaming- oder Brettspielaffinität hilft, ist aber keine Voraussetzung.
+
+### Kernemotionen
+**Geborgenheit → Eintauchen → Vorfreude**.
+
+### Designprinzipien
+- **Die Welt ist das Menü.**
+- **Fokus vor Gamification.** Während Fokus keine nötige Interaktion.
+- **Sanfte Verbindlichkeit statt Zwang.** Keine Strafen, keine Schuldkommunikation.
+- **Reale Zeit ist der Fortschritt.**
+- **Solo ist vollständig.** Multiplayer ist optional.
+- **Progression bedeutet Geschichte, nicht Macht.**
+- **Belohnung ohne Manipulation.** Keine bezahlten Lootboxen, keine FOMO-Mechaniken.
+
+### Anti-Ziele
+Kein komplexes RPG, kein Tamagotchi, kein Housing-Editor, kein Taskmanager, kein soziales Netzwerk, kein Produktivitätswettbewerb, kein Überwachungswerkzeug.
+
+### Ton
+Warm, ruhig, charmant, leicht humorvoll, nie albern oder pathetisch. Beispiel: „Ah. Da bist du ja. Das Feuer wusste offenbar, dass du wiederkommst.“
 
 ---
 
-## 1. Charakter und Völker
+## 2. Welt & Lager
 
-Beim ersten Start wählt man **ein Volk** und vergibt einen Namen. Das ist die ganze
-Charaktererstellung.
+Das persönliche **Lager** ist Heimat, Navigation, Fortschrittsanzeige und Erinnerung an vergangene Abenteuer.
 
+### Diegetische Navigation
+- Abenteuerbuch → Quests & Fokus
+- Charakter / Rucksack → Ausrüstung & Profil
+- Sammlung → Sets, Relikte, besondere Funde
+- Signalhorn → Gefährten & Party
+- Händlerwagen → kosmetische Käufe mit Gold
+- Einstellungen bleiben als konventionelles Zahnrad erreichbar
+
+### Lagerentwicklung
+Das Lager ist von Anfang an schön und gemütlich. Fortschritt bedeutet **klein → gewachsen → persönlich → voller Erinnerungen**, nicht „hässlich → hübsch“.
+
+Stufen:
+1. Kleines Lager
+2. Reiselager
+3. Abenteurerlager
+4. Außenposten
+
+Das strukturelle Wachstum endet bewusst; danach wächst vor allem die persönliche Geschichte.
+
+### Individualisierung
+Kuratierte Dekorationsslots statt freier Platzierung, z. B. Feuerstelle, Zelt, Licht, Sitzbereich, Banner, kleine Deko, großes Erinnerungsstück, Begleiterplatz.
+
+### Erinnerungen
+Besondere Quests, Sets und Meilensteine können dauerhafte Spuren im Lager hinterlassen: Karten, Relikte, Pflanzen, Trophäen, Begleiterplätze.
+
+### Regionen
+Mehrere visuell und erzählerisch unterschiedliche Regionen. Keine lineare Levelleiter, keine Power-Gates. Regionen bleiben langfristig relevant.
+
+### Rückkehr
+Abwesenheit hat keine negativen Folgen. Nichts verfällt, kein Begleiter wird traurig, kein Lager verwahrlost.
+
+---
+
+## 3. Gameplay & Quests
+
+### Core Loop
+**Lager → Abenteuerbuch → Quest wählen → Aufbrechen → Fokus → Questabschluss → Rast → Truhe → Lager**
+
+Die reale Fokusarbeit ist die eigentliche Spielhandlung. Wer während einer Quest nicht auf den Bildschirm schaut, verpasst nichts Notwendiges.
+
+### Abenteuerbuch
+Nachfüllender Questpool, ungefähr zehn Quests sichtbar. Keine Fristen, kein Ablauf, kein Leerstand. Dauer immer prominent.
+
+Filter/Lesezeichen: **15 · 25 · 50 · Episch**.
+
+### Questtypen
+| Typ | Fokusdauer | Struktur |
+|---|---:|---|
+| Kundschaftergang | 15 min | kleine Begegnung / Erkundung |
+| Kurze Quest | 25 min | normaler Fokusblock |
+| Mittlere Quest | 50 min | größere Reise |
+| Epische Quest | 3 × 25 min | drei Akte mit Rasten; Boss in Akt III |
+
+Epische Akte werden gespeichert und können an verschiedenen Tagen fortgesetzt werden.
+
+### Quest-Erzählstruktur
+1. **Vorher:** 1–2 Sätze Auftrag
+2. **Während:** visuelle, automatische Reise ohne nötige Interaktion
+3. **Nachher:** kurze erzählerische Auflösung
+
+### Aufbruch
+3–5 Sekunden Ritual: Charakter steht auf, nimmt Ausrüstung, Audio wechselt, Timer beginnt.
+
+### Fokus-Screen
+- Questname
+- dominante 2D-Abenteuerszene
+- sichtbarer, integrierter Timer
+- atmosphärischer Fortschrittsindikator
+- Pause
+- Audio
+- optional Vollbild
+- Quest verlassen
+
+**Der Timer ist Teil der Abenteuerwelt, nicht ein Overlay auf der Abenteuerwelt.**
+
+Keine Inventar-, Händler-, Sammlungs-, Chat- oder Interaktionsmechaniken während Fokus.
+
+### Questabschluss
+Bei `00:00` löst sich die Szene selbst auf. Kein schriller Alarm.
+
+Belohnung:
+- XP
+- Gold
+- Truhe verdient
+
+**Wichtig:** Die Reihenfolge ist **Questabschluss → Rast → Truhe öffnen**.
+
+### Rast
+Normal ca. 5 Minuten, lange Rast perspektivisch nach kumulierter Fokuszeit statt nach Questanzahl. Eine kleine optionale Handlung (z. B. Holz auflegen), danach aktive Einladung, den Bildschirm zu verlassen. Rast kann ohne Strafe übersprungen werden.
+
+### Abbruch
+Neutraler Dialog: bisherige Fokuszeit bleibt erhalten, Quest wird nicht abgeschlossen. Tatsächlich fokussierte Minuten geben XP; kein Questabschluss-Gold, keine Truhe.
+
+---
+
+## 4. Progression, Economy & Loot
+
+### XP
+**1 tatsächlich fokussierte Minute = 1 XP.**
+
+Keine Daily-XP, Streak-Boni, Längenmultiplikatoren oder „Perfect Focus“-Boni.
+
+### Level-Zielwerte
+| Level | kumulierte Fokuszeit |
+|---:|---:|
+| 2 | 30 min |
+| 5 | ca. 3 h |
+| 10 | ca. 10 h |
+| 20 | ca. 30 h |
+| 30 | ca. 60 h |
+| 50 | ca. 150 h |
+| 75 | ca. 300 h |
+| 100 | ca. 500 h |
+
+Kein hartes Max-Level. Level geben keine Produktivitätsvorteile.
+
+### Level-Meilensteine
+- normale Level: kleine kosmetische Belohnung
+- alle 5 Level: stärkere kosmetische Belohnung
+- alle 10 Level: großer sichtbarer Welt-/Charaktermoment, z. B. Begleiter oder Lagerentwicklung
+
+### Gold
+**1 Gold pro 5 erfolgreich abgeschlossenen Fokusminuten.**
+
+| Quest | Gold |
+|---|---:|
+| 15 min | 3 |
+| 25 min | 5 |
+| 50 min | 10 |
+| Epic 3×25 | 15 gesamt |
+
+Kleine narrative Bonusbeträge sind erlaubt. Gold kauft ausschließlich Kosmetik.
+
+### Loot
+Jede erfolgreich abgeschlossene Quest bzw. jeder entsprechende Questabschnitt erzeugt eine Truhe. Wenn eine Truhe ein Item enthält, ist es **neu**. Keine Duplikate.
+
+Vier Seltenheitsstufen:
+- Gewöhnlich 60 %
+- Ungewöhnlich 27 %
+- Selten 11 %
+- Außergewöhnlich 2 %
+
+Seltenheit ist rein kosmetisch und inszenatorisch.
+
+### Drei Herkunftsbereiche
+1. **Abenteuerfunde** – quest-only
+2. **Händlerwaren** – mit Gold auswählbar
+3. **Meilensteinobjekte** – weder normal kaufbar noch lootbar
+
+### Sets
+Thematische Sets mit sichtbarem Fortschritt, z. B. „Relikte des Flüsterwaldes 3/5“. Set-Abschluss kann Begleiter, Lagerobjekt oder besondere kosmetische Belohnung geben.
+
+### Ausrüstung
+Kosmetische Slots: Kopf, Oberkörper, Beine, Schuhe, Rücken, Hand/Werkzeug/Waffe, Accessoire. Ein Item funktioniert für alle Völker mit proportionaler Anpassung. Freigeschaltete Looks bleiben dauerhaft verfügbar; kein Auto-Equip.
+
+---
+
+## 5. Charaktere & Individualisierung
+
+### Völker
 **Mensch · Elf · Zwerg · Goblin · Ork**
 
-Die Wahl ist **Identität, keine Mechanik**. Sie bringt keine Zeiten, keine Attribute und
-keine Fähigkeiten mit. Der Charakter bleibt dauerhaft, geht auf alle Quests und levelt.
-Besondere Fähigkeiten kann er später erhalten — aber **als Gewinn, nicht als Anlage**
-(Entscheidung zu K1, Issue #27). Individualisiert wird er über erspielte Ausrüstung,
-Kleidung, Begleiter und Kosmetik.
+Reine Identität, keine Stats, keine Timerprofile, keine Boni.
 
-### Warum die Dauer an der Quest hängt und nicht am Charakter
+### Keine Klassen
+Es gibt keine Klassen und keine mechanischen Builds.
 
-Ein Timer, den man in einem Formular einstellt, wird nicht eingestellt. Deshalb war die
-Dauer in einem früheren Entwurf an eine Klasse gebunden — man wählte einen Charakter und
-bekam einen Arbeitsrhythmus dazu.
+### Keine Geschlechtsauswahl
+Die Anwendung fragt nicht nach Geschlecht/Gender. Körperform, Frisur, Bart, Farben und Ausrüstung sind frei kombinierbar.
 
-Der bessere Weg hängt sie an die **Quest**: Man wählt „Der verlassene Wachtturm ·
-Mittlere Quest · 50 Minuten", und das *ist* die Einstellung. Für die Zielgruppe ist das
-entscheidend — wer heute fünfzehn Minuten schafft und morgen fünfzig, soll nicht seinen
-Charakter wechseln müssen.
+### V1-Charaktererstellung
+- Volk
+- Körperform / Silhouette
+- Haut- bzw. Fantasyfarbe
+- Frisur
+- Haarfarbe
+- Name
 
-### Quest-Längen
+Keine Tattoos, Narben, Patches, Make-up-Systeme oder Detailslider.
 
-| Stufe | Dauer | Wegabschnitte |
-|---|---:|---:|
-| Kundschaftergang | 15 min | 3 |
-| Kurze Quest | 25 min | 4 |
-| Mittlere Quest | 50 min | 5 |
-| Epische Quest | 90 min | 6 |
+### Stil
+Stilisierte 2D-Fantasyfiguren, erwachsene Cozy Fantasy, nicht chibi. Mensch bodenständig, Elf elegant/naturverbunden, Zwerg kompakt/gemütlich, Goblin neugierig/expressiv, Ork stark aber warm („sanfter Riese“). Das sind Art-Tendenzen, keine vorgeschriebenen Persönlichkeiten.
 
-Der **Kundschaftergang** existiert, weil die Zielgruppe sonst beim Einstieg scheitert.
-Für Menschen, die Schwierigkeiten haben, lange fokussiert zu bleiben, sind 25 Minuten
-nicht der Anfang, sondern schon das Ziel (Entscheidung zu W3, Issue #30).
-
-**XP wird pro fokussierter Minute vergeben**, nicht pro Quest — sonst wäre der
-Kundschaftergang die effizienteste Art zu spielen.
-
-## 2. Der Zyklus
-
-```
-  Quest  ──▶  Truhe  ──▶  Rast  ──▶  Quest  ──▶ …
-   (4×)                                 │
-                                        ▼
-                              nach 4 Quests: Lange Rast
-```
-
-- **Quest (Fokus).** Die UI wird ruhig: Timer groß, alles andere zurückgenommen.
-  Auto-DND schaltet Systembenachrichtigungen stumm (übernommen vom Referenzprojekt).
-- **Truhe.** Erscheint nach jeder *abgeschlossenen* Quest. Öffnen ist optional und
-  jederzeit nachholbar — sie wartet im Inventar.
-- **Rast.** Warme Farben, Lagerfeuer, Atem-Animation. Ein Timer, der zur Pause einlädt
-  statt sie zu bewachen. Es gibt **eine** Handlung — Holz auflegen, ein Klick, drei
-  Sekunden — und danach verabschiedet der Screen aktiv: „Das Feuer hält. Geh ruhig."
-  Keine Minispiele: Der Zweck der Rast ist, vom Bildschirm wegzukommen, und eine
-  Tätigkeit, die fünf Minuten füllt, erreicht das Gegenteil (W1, Issue #30).
-- **Lange Rast.** Jede vierte Rast, in der Taverne. Hier gibt es die Zusammenfassung
-  des Blocks: geschaffte Quests, verdiente XP, Party-Statistik.
+### Begleiter
+Rein kosmetisch-emotional, keine Werte, keine Bedürfnisse, keine Schuldmechanik. Können aus Meilensteinen, Sets oder besonderen Quests stammen.
 
 ---
 
-## 3. Truhen und Loot
+## 6. Solo, Gefährten & Party
 
-Fünf Seltenheitsstufen, angelehnt an die etablierte D&D-/Loot-Konvention:
+Solo ist Standard und vollständig.
 
-| Stufe | Farbe | Chance |
-|---|---|---:|
-| Gewöhnlich | Grau | 55 % |
-| Ungewöhnlich | Grün | 25 % |
-| Selten | Blau | 13 % |
-| Episch | Violett | 6 % |
-| Legendär | Gold | 1 % |
+### Einladung
+Signalhorn im Lager. **Einladungslink ist Standard**, kurzer Party-Code bleibt Fallback. Konto + Charakter sind Pflicht.
 
-Inhalt: **XP**, **Gold** und gelegentlich ein **Item** (rein kosmetisch — Titel,
-Charakter-Rahmen, Truhen-Skins). Es gibt bewusst **keine Items mit Spielvorteil** und
-**keine Käufe**. Loot ist Feedback, keine Währung.
+Keine Freundesanfrage nötig. Nach einer gemeinsamen Quest kann man jemanden optional **als Gefährten merken**.
 
-**Die Öffnungs-Animation ist ein eigenes Feature, kein Detail.** Sie ist der Moment,
-in dem die Belohnung passiert — sie bekommt Zeit, Sound und einen sauberen
-Reduced-Motion-Fallback. Siehe `#junDev Chest-Opening-Animation`.
+### Gemeinsame Quest
+- eine gemeinsame Quest
+- eine gemeinsame Uhr
+- Bereitschaftsprüfung für alle
+- kein Dungeon Master
+- keine automatische Countdown-Startlogik
+- alle Charaktere sichtbar in derselben Szene
 
----
+### Fokus
+**Kein Chat, keine Emojis, keine Pings, keine Reactions.** Leitidee: **Zusammen allein.**
 
-## 4. Party — das Kernfeature
+### Abbruch
+Gilt nur für die eigene Person. Andere laufen weiter und verlieren nichts.
 
-### Beitreten
+### Rewards
+Individuelle Belohnungen und individuelle Truhen. **Keine Party-Truhe.** Optional kleiner additiver Goldbonus, kein XP-Multiplikator, keine besseren Lootchancen.
 
-Ein **5-stelliger Code**, z. B. `H26HE`. Zeichensatz: `0-9 A-Z` **ohne `I`, `L`, `O`, `U`**
-— `I/L/1` und `O/0` sind beim Vorlesen nicht unterscheidbar, und das fehlende `U`
-verhindert versehentlich entstehende Wörter. Bleiben 32 Zeichen, also 32⁵ ≈ **33,5 Mio.**
-Kombinationen. Eingabe ist case-insensitive; die Anzeige ist immer Großbuchstaben.
-
-Beitreten setzt ein Konto und einen Charakter voraus (Entscheidung zu W5, Issue #30) —
-der Charakter muss ja am Lagerfeuer sitzen und seine XP behalten können. Der Beitritt
-selbst bleibt eine einzige Eingabe: Code eintippen, fertig.
-
-Eingeladen wird **im Lager**, über das Signalhorn. Es gibt keinen getrennten
-Multiplayer-Bereich; die Gefährten setzen sich sichtbar mit ans Feuer.
-
-### Gemeinsam arbeiten
-
-- **Eine Uhr für alle.** Alle Mitglieder sehen exakt dieselbe verbleibende Zeit.
-  Technisch gelöst über Server-Zeitstempel statt Countdown — siehe
-  [SYNC-PROTOCOL.md](SYNC-PROTOCOL.md).
-- **Eine gemeinsame Quest.** Die Party ist zusammen unterwegs. Der Party-Screen zeigt
-  alle Mitglieder mit Volk und Status.
-- **Gruppenquests geben dasselbe.** XP, Gold und Loot fallen genauso an wie im
-  Alleingang. Zusätzlich gibt es eine Party-Truhe, deren Stufe mit der Zahl der
-  Mitglieder steigt, die durchgezogen haben — **rein additiv**. Niemand bekommt
-  weniger, weil jemand anderes abbricht.
-
-### Wer steuert? Niemand.
-
-Es gibt **keinen Dungeon Master**. Der Aufbruch geschieht per **Bereitschaftsprüfung**:
-Alle bestätigen, dann bricht die Gruppe gemeinsam auf.
-
-Das ist nicht nur freundlicher, es beseitigt eine ganze Klasse von Problemen — keine
-Rolle, die weitergereicht werden muss, wenn jemand geht; keine Gruppe, die auf eine
-Person wartet; kein sozialer Druck durch eine Person, die alle anderen steuert.
-
-| Handlung | Regel |
-|---|---|
-| Aufbruch | erst wenn **alle** bereit sind |
-| Rast | folgt automatisch, niemand löst sie aus |
-| Abbruch | gilt **nur für einen selbst** — die anderen laufen weiter |
-| Beitritt während einer Quest | jederzeit, man steigt an der aktuellen Stelle ein |
-
-Niemand verliert XP, Gold oder Loot, weil eine andere Person abbricht.
+### Laufende Quest
+Kein erstmaliger Drop-in mitten in eine laufende Quest. Eingeladene warten auf die nächste Quest. Reconnect/Reload ist dagegen eine Wiederherstellung und muss funktionieren.
 
 ---
 
-## 5. Was bewusst *nicht* dabei ist
+## 7. UX, Onboarding & User Journey
 
-| Nicht dabei | Grund |
-|---|---|
-| Leaderboards über alle Nutzer | Erzeugt Konkurrenz statt Fokus. Innerhalb der Party reicht Sichtbarkeit. |
-| Streak-Verlust / "du hast X verloren" | Bestraft Krankheit und Urlaub. Streaks wachsen, sie brechen nicht. |
-| Käufe, Premium, Lootboxen mit Geld | Loot ist Feedback. Sobald Geld im Spiel ist, ist es das nicht mehr. |
-| Tracking, wer wie lange gearbeitet hat, für Dritte | Das ist ein Fokus-Tool, kein Überwachungswerkzeug. |
+### Einstieg
+Erster Besuch beginnt in der Welt, nicht auf einer Marketingfolie.
+
+> „Ah. Da bist du ja.“
+>
+> „Wir haben noch einen Platz am Feuer.“
+
+Danach minimaler Account und minimale Charaktererstellung.
+
+### Erstes Lager
+Bereits gemütlich, aber klein. Das Abenteuerbuch lenkt subtil Aufmerksamkeit auf sich.
+
+### Erste Quest
+Kuratiert: **„Ein Licht im Unterholz“ · 15 Minuten**. Es ist eine echte Quest, kein Tutorial-Simulator.
+
+### Erstes Erlebnis
+Aufbruch → Fokus → Abschluss → XP/Gold + Truhe → Rast → erste Truhe.
+
+Die erste Truhe ist **deterministisch**, z. B. **Alte Weglaterne**. Danach erscheint das Objekt sichtbar im Lager. So lernt die Person: **Meine echte Fokuszeit verändert diese Welt.**
+
+### Progressive Discovery
+Sammlung, Händler, Sets und Begleiter werden erst dann sichtbar/erklärt, wenn sie relevant werden.
+
+### Wiederkehrende Nutzung
+Lager → Quest → Aufbrechen soll bei klarer Absicht in ca. 10–15 Sekunden möglich sein.
+
+### Gerätewechsel
+Laufende Quest kann auf anderem Gerät mit korrekter Restzeit fortgesetzt werden: „Du bist noch unterwegs.“
+
+---
+
+## 8. Art Direction, Motion & Audio
+
+### Visuelle Leitidee
+**Ein illustriertes Fantasy-Abenteuerbuch, dessen Seiten lebendig geworden sind.**
+
+2D-Illustration mit leicht erhöhter diagonaler 2.5D-/Diorama-Perspektive. Kein echtes 3D.
+
+### Zielästhetik
+Adult Cozy Fantasy mit Pen-&-Paper-Seele. Nicht chibi, nicht fotorealistisch-düster, nicht Mobile-Game-glitzernd, nicht SaaS mit Fantasy-Skin.
+
+### Farb- und Materialwelt
+Draußen tiefe Blau-, Grün-, Grau- und Violetttöne. Lager warm mit Feuer, Bernstein, Messing, Leder, Holz und Pergament. Materialien: Pergament, Holz, Leder, Stoff, patiniertes Metall, Stein, Tinte.
+
+### Licht
+Licht ist UX-Mittel: Buch, Händler, neue Funde oder wichtige Orte können durch Licht statt Badges/Pfeile geführt werden.
+
+### Typografie
+Charaktervolle Serifenschrift für Titel/Narration, sehr gut lesbare funktionale Schrift für Timer, Zahlen, Einstellungen und längere Texte.
+
+### Motion
+Lebendes Bilderbuch: Feuer, Blätter, Stoff, Haare, Atmung, Licht. Große Bewegungen nur für bedeutende Momente. Fokusphase bleibt ruhig.
+
+### Audio
+Drei getrennte Ebenen: Musik, Umgebung, Effekte. Camp ruhig und atmosphärisch. Kurzes wiederkehrendes Aufbruchsmotiv. Fokus-Modi: Abenteuermusik, Natur, Lagerfeuer/Ambiente, Stille. Questende löst das Motiv auf statt zu piepen. Truhen klingen materiell, nicht wie Glücksspiel.
+
+---
+
+## 9. Accessibility, Settings & Schutzmechanismen
+
+Accessibility ist Bestandteil des Designs.
+
+### Verbindlich
+- semantische HTML-Strukturen
+- sinnvolle Accessible Names
+- vollständige Tastaturbedienung
+- sichtbare Fokuszustände
+- Informationen nie nur über Farbe
+- ausreichend große Touch-Ziele
+- Browser-Zoom und größere Schrift müssen funktionieren
+- `prefers-reduced-motion` respektieren + In-App-Option
+- wichtige Informationen nie nur per Audio
+
+### Timerdarstellung
+- exakt: `18:42`
+- vereinfacht: „Noch etwa 20 Minuten“
+- atmosphärisch: nur visueller Reisefortschritt
+
+Keine Auswirkung auf Rewards.
+
+### Ruhiger Fokus
+Reduzierte visuelle Veränderung, keine schlechteren Belohnungen.
+
+### No-Dark-Patterns-Charta
+- keine Streak-Pflicht
+- keine Daily Rewards
+- keine künstliche Verknappung
+- keine Countdown-Shops
+- keine bezahlten Lootboxen
+- keine absichtlichen Duplikate
+- keine Vernachlässigungsmechaniken
+- keine Schuldkommunikation
+- keine Produktivitätsrankings
+- keine Nachteile für Accessibility-Einstellungen
+- keine Mechanik, die Menschen absichtlich länger am Bildschirm hält
+
+**Leitregel:** Die Anwendung respektiert Aufmerksamkeit als begrenzte Ressource – sie versucht nicht, sie zu besitzen.
+
+---
+
+## 10. Technische Leitplanken, MVP & Roadmap
+
+### Web First
+Responsive Web-App, Desktop als größte Bühne, Mobile voll funktionsfähig. Native Apps nicht im initialen Scope.
+
+### Persistenz
+Account-basierte serverseitige Persistenz für Charakter, XP, Level, Gold, Inventar, Sammlung, Lager, Begleiter, Questfortschritt und relevante Einstellungen.
+
+### Zeitmodell
+Der Timer zeigt Zustand an, er ist nicht selbst der Zustand. Laufende Quest basiert auf autoritativer Zeitinformation und überlebt Reload, Gerätewechsel und kurze Verbindungsabbrüche.
+
+### Journey statt Game Engine
+Visuelle Reise wird aus `elapsed / duration` abgeleitet. Keine Physik- oder Kampf-Simulation notwendig.
+
+### Content datengetrieben
+Quests, Regionen, Items, Sets und Lootpools sollen aus Daten statt hart verdrahteter UI-Logik entstehen.
+
+### Loot zuverlässig
+Reward-Ereignisse autoritativ und nachvollziehbar; Besitzstand verhindert Duplikate.
+
+### Party-Sync
+Gemeinsame Session mit Mitgliedern, Bereitschaft, Quest, Startzeit und Status. Reconnect ist Wiederherstellung, kein neuer Beitritt.
+
+### Progressive Loading
+Nur aktuelle/relevante Assets priorisieren. Fokusfunktion muss robuster sein als Animation, Audio oder dekorative Assets.
+
+### MVP
+Zwingend:
+- Account & Login
+- minimale Charaktererstellung mit fünf Völkern
+- Startlager
+- Abenteuerbuch
+- 15/25/50-Minuten-Quests
+- Aufbruchsritual
+- Fokus-Screen mit integriertem Timer
+- Pause & Abbruch
+- XP, Gold, Questabschluss
+- Rast vor Truhe
+- No-Duplicate-Loot
+- Inventar / kosmetische Ausrüstung
+- erste sichtbare Lagerprogression
+- Basis-Audio
+- Accessibility-Grundfunktionen
+- responsive Desktop/Mobile Experience
+
+Nicht im ersten MVP:
+- Party
+- Gefährtenliste
+- großer Händlerumfang
+- große Set-Sammlung
+- Begleitersystem
+- vollständige Lagerstufen
+- epische Quests
+- native Apps/PWA-Extras
+
+### Roadmap
+1. **Vertical Slice:** Waldintro → Account → Charakter → Lager → „Ein Licht im Unterholz“ → 15 Min Fokus → Abschluss → Rast → deterministische Weglaterne.
+2. **Core MVP:** mehrere Regionen, 15/25/50, XP/Level/Gold/Loot/Ausrüstung, erste Lagerentwicklung, Settings, Sync.
+3. **Weltvertiefung:** Händler, Sets, Begleiter, mehr Regionen, Lagerstufen.
+4. **Gemeinsam aufbrechen:** Signalhorn, Link/Code, Ready Check, gemeinsame Uhr, Gefährten.
+5. **Epische Abenteuer:** 3×25 mit persistentem Aktfortschritt.
+6. **Langfristige Welt:** weitere Begleiter, Sets, Regionen, Events, PWA/weitere Plattformen.
+
+### Oberste technische Leitregel
+**Die Fokuszeit der Person ist heiliger als die Spielinszenierung.**

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,220 +1,164 @@
-# Architecture Decision Records
+# Architecture & Product Decision Records
 
-Kurz halten. Vier Zeilen reichen. Der Zweck ist, dass in sechs Monaten niemand eine
-Entscheidung zurückdreht, ohne den Grund zu kennen — und dass das übernehmende Team
-nicht raten muss.
+> Historische ADRs bleiben nachvollziehbar, aber **Concept V2 ist die verbindliche Produktspezifikation**. Bei Widerspruch gilt die neuere Entscheidung in diesem Dokument bzw. `CONCEPT.md`.
 
-Format: **Kontext · Entscheidung · Alternative · Grund** — plus Status.
+Format: **Kontext · Entscheidung · Alternative · Grund**.
 
 ---
 
+## Weiterhin gültige technische Entscheidungen
+
 ### ADR-001 · Supabase Realtime statt eigenem WebSocket-Server
-**Status:** angenommen · 2026-09-04
-**Kontext:** Die Party braucht Echtzeit-Synchronisation.
-**Entscheidung:** Supabase Realtime Broadcast.
-**Alternative:** Eigener Node/Bun-WebSocket-Service mit Redis.
-**Grund:** Das Protokoll überträgt Phasenwechsel, keine Ticks — wenige Nachrichten pro
-halbe Stunde und Party. Ein eigener Service wäre Infrastruktur ohne passende Last, und
-das übernehmende Team müsste ihn betreiben.
+**Status:** angenommen · 2026-09-04  
+**Kontext:** Party braucht Echtzeit-Synchronisation.  
+**Entscheidung:** Supabase Realtime Broadcast.  
+**Grund:** Das Protokoll überträgt Zustandswechsel, keine sekündlichen Ticks.
 
-### ADR-002 · Der Timer ist ein Zeitstempel, kein Countdown
-**Status:** angenommen · 2026-09-04
-**Kontext:** Alle Mitglieder müssen dieselbe Zeit sehen.
-**Entscheidung:** Server hält `phase_started_at` + `phase_duration_s`; Clients rechnen
-die Restzeit selbst aus und korrigieren über einen gemessenen Uhren-Offset.
-**Alternative:** Server sendet jede Sekunde die Restzeit.
-**Grund:** Übernimmt das Prinzip des Referenzprojekts (Zustand an der Wanduhr verankert).
-Überlebt Reconnects, Hintergrund-Tabs und Standby ohne Sonderbehandlung, und ein später
-beitretendes Mitglied ist sofort korrekt. Sekündliches Senden wäre teurer *und* fragiler.
+### ADR-002 · Timer ist Zeit-/Sessionzustand, kein lokaler Countdown
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Autoritative Zeitinformation; Clients leiten Restzeit daraus ab.  
+**Grund:** Überlebt Reload, Hintergrund-Tab, Gerätewechsel, Reconnect und Party-Sync.
 
-### ADR-003 · Fünfstelliger Code aus 32 Zeichen ohne I, L, O, U
-**Status:** angenommen · 2026-09-04
-**Kontext:** Der Code wird vorgelesen und abgetippt.
-**Entscheidung:** `0-9 A-Z` ohne `I L O U`, Länge 5 → 33,5 Mio. Kombinationen.
-**Alternative:** UUID-Kurzform oder sechs Zeichen.
-**Grund:** `I/L/1` und `O/0` sind beim Vorlesen nicht unterscheidbar; ohne `U` entstehen
-keine ungewollten Wörter. Fünf Zeichen bleiben am Telefon durchsagbar. Gegen das Erraten
-schützen Rate-Limits, nicht die Länge.
-
-### ADR-004 · Verpasste Phasen — nachholen oder verfallen?
-**Status:** **offen** — Entscheidung im Review von M3
-**Kontext:** Waren alle Clients über einen Phasenwechsel offline, ist unklar, was gilt.
-**Empfehlung:** Verfallen, Party geht in `idle`. Nachträgliches Gutschreiben lädt dazu
-ein, Fortschritt durch Wegklicken zu erzeugen — und entwertet damit die Belohnung.
-
-### ADR-005 · Dunkel als Standard
-**Status:** angenommen · 2026-09-04
-**Kontext:** Welcher Modus ist voreingestellt?
-**Entscheidung:** Dunkel, mit vollwertigem hellen Modus und System-Erkennung.
-**Alternative:** Hell, oder ausschließlich System.
-**Grund:** Aus der Nutzungssituation, nicht aus Geschmack: Der Timer steht stundenlang
-im Randblickfeld, oft abends. Eine helle Fläche, die 25 Minuten leuchtet, ermüdet.
-
-### ADR-006 · Loot ist kosmetisch und nicht kaufbar
-**Status:** angenommen · 2026-09-04
-**Kontext:** Was steckt in den Truhen?
-**Entscheidung:** XP, Gold und rein kosmetische Fundstücke. Kein Kauf, keine Spielvorteile.
-**Alternative:** Freischaltbare Funktionen oder Premium-Inhalte.
-**Grund:** Loot ist hier Rückmeldung für getane Arbeit. Sobald man es kaufen kann, ist
-es keine Rückmeldung mehr, sondern eine Währung — und die Motivation kippt.
+### ADR-003 · Kurzer Party-Code als Fallback
+**Status:** **geändert durch ADR-024**  
+Der bestehende fünfstellige Code kann als Fallback bestehen bleiben, ist aber nicht mehr der primäre Einladungsweg.
 
 ### ADR-007 · Keine Game-Engine
-**Status:** angenommen · 2026-09-04
-**Kontext:** Wanderung, Truhen und Kulissen brauchen Bewegung.
-**Entscheidung:** SVG und CSS, dazu `motion` für Choreografie. Kein Phaser, kein PixiJS, kein Three.js.
-**Alternative:** Eine der genannten Engines.
-**Grund:** Ein WebGL-Canvas, der 50 Minuten am Stück rendert, ist in einer Fokus-App
-ein Fehler — er zieht Akku, lässt den Lüfter angehen und holt sich Aufmerksamkeit, die
-gerade woanders gebraucht wird. Dazu 150–600 kB Laufzeit für Physik, Sprite-Batching und
-Szenengraph, von denen wir nichts nutzen.
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** 2D-Webdarstellung; keine Phaser/Pixi/Three-Game-Engine ohne neue belegte Notwendigkeit.  
+**Grund:** Fokus-App benötigt Illustration und zeitbasierte Zustände, keine Physik- oder Kampfsimulation.
 
-### ADR-008 · Die Wanderung ist abgeleiteter Zustand
-**Status:** angenommen · 2026-09-04
-**Kontext:** Die Gruppe soll während der Quest sichtbar unterwegs sein.
-**Entscheidung:** `Position = verstrichene Zeit / Quest-Dauer`. Keine eigene
-Animationsschleife, keine gespeicherte Position.
-**Alternative:** Eine Animation mit eigenem Zeitgeber, die bei Phasenwechseln
-zurückgesetzt und über die Party synchronisiert wird.
-**Grund:** Dieselbe Idee wie ADR-002. Damit ist die Wanderung nach Hintergrund-Tab,
-Standby und für spät beitretende Mitglieder automatisch korrekt — ohne eine Zeile
-Synchronisationscode. Die Alternative wäre ein zweites Sync-Problem neben dem, das
-wir schon gelöst haben.
+### ADR-008 · Journey ist abgeleiteter Zustand
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Visueller Fortschritt wird aus verstrichener Zeit / Questdauer abgeleitet.  
+**Grund:** Robuste Wiederherstellung und Synchronisation ohne zweite Animationsuhr.
 
-### ADR-009 · Rive nur für die Höhepunkte
-**Status:** angenommen · 2026-09-04
-**Kontext:** Die Truhe hat fünf Seltenheitsstufen mit derselben Choreografie.
-**Entscheidung:** Rive für Truhe, Stufenaufstieg und Party-Truhe. Alles andere in CSS
-und `motion`. Die Laufzeit wird erst bei `progress > 0.9` nachgeladen.
-**Alternative:** Alles handanimiert, oder Lottie.
-**Grund:** Fünf handanimierte Varianten derselben Choreografie laufen auseinander,
-sobald jemand eine davon anfasst. Rives State Machine hält sie in einer Datei zusammen
-und macht sie ohne Deployment änderbar. Der Preis — 200 kB WASM und ein Werkzeug, das
-jemand bedienen muss — ist nur für diese wenigen Momente gerechtfertigt, nicht für
-Übergänge oder Icons. Lottie bringt bei größerem Aufwand keinen Zusatznutzen, solange
-niemand im Team ohnehin mit After Effects arbeitet.
+### ADR-011 · Item-Baukasten bleibt technisches Hilfsmittel
+**Status:** angenommen mit neuer Rolle  
+Der bestehende Baukasten kann Darstellung liefern; Produktwahrheit ist der katalogisierte, dauerhaft freischaltbare Gegenstand mit No-Duplicate-Regel.
 
-### ADR-010 · Hybride Kunstrichtung mit scharfer Grenze
-**Status:** angenommen · 2026-09-04
-**Kontext:** Die Oberfläche ist Linienzeichnung, das Spiel braucht reichere Bilder.
-**Entscheidung:** Oberfläche bleibt Linie. Illustration ausschließlich innerhalb
-begrenzter Felder: Item-Kachel, Truhen-Podest, Wanderungs-Band.
-**Alternative:** Alles illustrieren, alles Linie lassen, oder Pixel-Art.
-**Grund:** Der Hybrid trägt nur, solange die Grenze scharf ist. Ein Verlauf zwischen
-beiden Welten ist genau der Punkt, an dem so etwas nach zwei Projekten aussieht. Mit
-Rahmen liest sich Illustration als *Abbildung eines Gegenstands* statt als Dekoration
-der Oberfläche.
+### ADR-012 · Quests werden als Content gepflegt, nicht aus Satzbausteinen erzeugt
+**Status:** angenommen  
+Vorhandener Questcontent darf weiterverwendet werden, sofern Ton, Dauer und Struktur Concept V2 entsprechen.
 
-### ADR-011 · 576 Gegenstände aus 26 gezeichneten Teilen
-**Status:** angenommen · 2026-09-04
-**Kontext:** Der Spielinhalt braucht viele unterscheidbare Gegenstände.
-**Entscheidung:** 12 Grundformen × 6 Materialien × 8 Embleme, deterministisch aus der
-Item-Kennung abgeleitet. Ein optionales Feld `art` überschreibt mit einer Illustration.
-**Alternative:** Jeden Gegenstand einzeln zeichnen, oder generieren lassen.
-**Grund:** Bildwiederholung fällt weit weniger auf als Textwiederholung — genau umgekehrt
-zu den Quests, die deshalb einzeln geschrieben sind. Der Baukasten geht sofort live und
-bleibt automatisch auf Strichstärke; Illustrationen kommen nach Seltenheit priorisiert
-dazu, ohne dass ein Screen darauf wartet. Generierte Icons scheiden aus, weil man
-Seltenheit erkennen können muss und 576 Einzelgenerierungen nie zueinander passen.
-
-### ADR-012 · 100 einzeln geschriebene Quests statt Textbausteinen
-**Status:** angenommen · 2026-09-04
-**Kontext:** In einem Arbeitstag laufen bis zu 16 Quests. Wiederholung fällt sofort auf.
-**Entscheidung:** 100 von Hand geschriebene Quests in acht Regionen, mit je 3–5
-Wegabschnitten, als `content/quests.de.json`. Auswahl deterministisch aus Party-Code
-und Zyklus, zuletzt gespielte ausgeschlossen.
-**Alternative:** Prozedural aus Satzbausteinen erzeugen.
-**Grund:** Kombinierter Text liest sich nach dem dritten Mal wie kombinierter Text.
-Das ist bei Bildern anders (siehe ADR-011) — bei Sprache merkt man das Raster sofort.
-100 Quests decken auch einen sehr langen Tag ohne Wiederholung ab.
-
-### ADR-013 · Ein Volk, dauerhaft, ohne Mechanik
-**Status:** angenommen · 2026-09-04 (Issue #27)
-**Kontext:** Konzept V1 §4 verlangt Völker ohne Klassen; das ursprüngliche Briefing
-sprach von einer Klasse, die auf Quests geht.
-**Entscheidung:** Ein Volk (Mensch, Elf, Zwerg, Goblin, Ork), einmal gewählt, dauerhaft.
-Reine Identität — keine Zeiten, keine Attribute, keine angeborenen Fähigkeiten.
-Besondere Fähigkeiten gibt es **als Gewinn**, nicht als Anlage.
-**Alternative:** Sechs Klassen, die zugleich das Timer-Profil setzen.
-**Grund:** Die Dauer gehört an die Quest, nicht an den Charakter. Wer heute fünfzehn
-Minuten schafft und morgen fünfzig, soll nicht den Charakter wechseln müssen — gerade
-bei einer Zielgruppe, deren Belastbarkeit von Tag zu Tag schwankt.
+### ADR-013 · Fünf Völker, keine mechanischen Klassen
+**Status:** angenommen  
+Mensch, Elf, Zwerg, Goblin, Ork. Reine Identität. Quest bestimmt Fokusdauer.
 
 ### ADR-014 · Kein Gastzugang
-**Status:** angenommen · 2026-09-04 (Issue #30, W5)
-**Kontext:** Ein Gastzugang senkt die Hürde für den Gruppenbeitritt erheblich.
-**Entscheidung:** Konto und Charakter sind Pflicht. Kein anonymer Beitritt.
-**Alternative:** Gast für die Sitzung, Belohnungen später gutschreiben.
-**Grund:** Fortschritt, Inventar und Level müssen geräteübergreifend erhalten bleiben,
-und der Charakter muss am Lagerfeuer sitzen können. Ein Gast ohne Charakter hat im
-Lager keinen Platz — die Metapher trägt ihn nicht.
-**Preis, den wir dafür zahlen:** Der Login ist die härteste Hürde der App und steht vor
-dem ersten Erlebnis. Der Login-Screen trägt dafür besondere Verantwortung: kein Passwort,
-keine Bestätigungsmail vor dem Betreten, und der Text nennt den Grund.
+**Status:** angenommen  
+Konto und Charakter sind für persistente Nutzung und Party erforderlich.
 
 ### ADR-015 · Bereitschaftsprüfung statt Dungeon Master
-**Status:** angenommen · 2026-09-04 (Issue #28)
-**Kontext:** Wer startet, pausiert und überspringt in einer Gruppe?
-**Entscheidung:** Niemand. Aufbruch, wenn alle bereit sind; Rast folgt automatisch;
-Abbruch gilt nur für einen selbst.
-**Alternative:** Ein Dungeon Master steuert, die Rolle wandert beim Verlassen.
-**Grund:** Beseitigt eine ganze Klasse von Problemen — keine Rolle, die weitergereicht
-werden muss; keine Gruppe, die auf eine Person wartet; kein sozialer Druck durch eine
-Person, die alle anderen steuert.
+**Status:** angenommen  
+Alle bestätigen vor dem gemeinsamen Aufbruch. Individueller Abbruch betrifft nur die eigene Person.
 
-### ADR-016 · Das Abenteuerbuch läuft nie leer
-**Status:** angenommen · 2026-09-04 (Issue #30, W2)
-**Kontext:** Konzept V1 §5 sieht zehn Quests pro Woche vor.
-**Entscheidung:** Zehn Quests als kuratierte Auswahl, aber abgeschlossene werden
-**ersetzt, nicht gestrichen**. Der Wochenwechsel mischt neu und nimmt nichts weg; es
-gibt keine Frist und keine Ablaufkommunikation.
-**Alternative:** Feste zehn pro Woche, danach leeres Buch.
-**Grund:** Bei sechs Quests am Tag wäre die Woche nach zwei Tagen vorbei — genau bei
-den Nutzern, die am meisten arbeiten. Und „die Quests dieser Woche" erzeugt die Sorge,
-etwas zu verpassen, die Konzept V1 §14 ausschließt.
+### ADR-016 · Abenteuerbuch läuft nie leer
+**Status:** angenommen  
+Ungefähr zehn sichtbare Quests; abgeschlossene werden nachgefüllt. Keine Frist-/Expiry-Kommunikation.
 
-### ADR-017 · Vier Quest-Längen, kürzeste 15 Minuten
-**Status:** angenommen · 2026-09-04 (Issue #30, W3)
-**Kontext:** Konzept V1 §6 bot 25, 50 und 90 Minuten an.
-**Entscheidung:** Vier Stufen — Kundschaftergang 15, Kurze Quest 25, Mittlere Quest 50,
-Epische Quest 90 (letztere noch in Klärung, Issue #32).
-**Alternative:** Bei drei Stufen ab 25 Minuten bleiben.
-**Grund:** Konzept V1 §1 adressiert ausdrücklich Menschen, die Schwierigkeiten haben,
-lange fokussiert zu bleiben. Wäre 25 Minuten die kürzeste Stufe, wäre der Einstieg für
-einen erheblichen Teil dieser Zielgruppe der erste Misserfolg.
+### ADR-018 · Epische Quest ist 3×25 Minuten
+**Status:** angenommen  
+Drei persistente Akte mit Rasten; Boss/Höhepunkt in Akt III. Kein 90-Minuten-Dauerblock.
 
-### ADR-018 · Die epische Quest ist ein Bogen, kein Block
-**Status:** angenommen · 2026-09-04 (Issue #32)
-**Kontext:** Konzept V1 §6 setzte die epische Quest auf ca. 90 Minuten.
-**Entscheidung:** Drei Fokusabschnitte à 25 Minuten mit Rasten dazwischen, erzählt als
-**eine** Quest. Der Bosskampf ist der dritte Abschnitt. Gesamtfokuszeit 75 Minuten.
-**Alternative:** Neunzig Minuten am Stück.
-**Grund:** Ein ununterbrochener 90-Minuten-Block widerspricht dem Grundsatz, auf dem die
-Methode beruht, und trifft ausgerechnet die Zielgruppe aus Konzept V1 §1. Das epische
-Gefühl bleibt, die Pausen bleiben drin, und der Wiedereinstieg ist erzählerisch motiviert.
-**Technische Folge:** `arcProgress()` rechnet den Fortschritt über alle drei Abschnitte.
-Ohne das spränge die Kulisse bei jeder Rast an den Anfang zurück.
+---
 
-### ADR-019 · Ruhiger Ton bei kurz und mittel, laut nur beim Boss
-**Status:** angenommen · 2026-09-04 (Issue #31)
-**Kontext:** Konzept V1 fordert Cozy Fantasy mit Drachen; der vorhandene Questpool war
-karg und ohne Kreaturen.
-**Entscheidung:** Kundschaftergang, kurze und mittlere Quests behalten den ruhigen,
-beobachtenden Ton. Epische Quests und Bosskämpfe dürfen laut sein.
-**Alternative:** Durchgängig ein Ton.
-**Grund:** Konzept V1 §15 macht die Unterscheidung selbst („Fokusoberfläche: ruhig",
-„Bosskämpfe: deutlich epischer"). Kurze und mittlere Quests laufen nebenher, während
-jemand arbeitet — dort ist Zurückhaltung keine Stilfrage, sondern Funktion. Epische
-Quests sind eine pro Woche und dürfen tragen.
-**Umsetzung:** Jede Region trägt `theme` (Zuordnung zu Konzept V1 §5) und `tone`.
-Ein Test hält den lauten Wortschatz aus den nicht-epischen Quests heraus.
+## Concept-V2-Entscheidungen
 
-### ADR-020 · Mindestgrößen der Loot-Töpfe sind hergeleitet, nicht geschätzt
-**Status:** angenommen · 2026-09-04 (Issue #33)
-**Kontext:** „Keine Duplikate" hält nur, solange die Töpfe reichen.
-**Entscheidung:** 40 gewöhnliche, 20 seltene, 12 epische und 12 legendäre Einträge je
-Kategorie. Insgesamt 336 Einträge in 16 Töpfen.
-**Grund:** Bei acht Quests am Tag und vier Kategorien zieht ein Topf
-`8 × Wahrscheinlichkeit ÷ 4` Mal täglich — für gewöhnlich 1,2. Vierzig Einträge halten
-damit gut einen Monat. Der erste Entwurf hatte zwanzig, und der Reichweiten-Test deckte
-auf, dass es innerhalb von 30 Tagen 65-mal Gold statt eines Gegenstands gegeben hätte.
-Die Zahl steht jetzt als Test, nicht als Annahme.
+### ADR-021 · Vier Seltenheitsstufen
+**Status:** angenommen · 2026-09-04  
+**Kontext:** Ältere Dokumente nannten fünf Stufen.  
+**Entscheidung:** Gewöhnlich 60 %, Ungewöhnlich 27 %, Selten 11 %, Außergewöhnlich 2 %.  
+**Grund:** Einfacheres No-Duplicate-System und klarere kosmetische Progression.
+
+### ADR-022 · Questabschluss → Rast → Truhe
+**Status:** angenommen · 2026-09-04  
+**Kontext:** Frühere Schleife öffnete Loot vor der Pause.  
+**Entscheidung:** Nach Abschluss werden XP/Gold und eine wartende Truhe angezeigt; zuerst Rast, danach Lootöffnung.  
+**Grund:** Die Belohnung darf die reale Pause nicht am Bildschirm auffressen.
+
+### ADR-023 · Keine Streaks
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Keine Tagesstreaks, auch keine „unzerbrechlichen“ Streaks.  
+**Grund:** Kalenderbasierte Serien erzeugen impliziten Druck und widersprechen der No-Dark-Patterns-Charta.
+
+### ADR-024 · Einladungslink primär, Code als Fallback
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Signalhorn erzeugt bevorzugt einen teilbaren Einladungslink; kurzer Party-Code bleibt für Vorlesen/anderes Gerät verfügbar.  
+**Grund:** Link minimiert Reibung, Code bleibt praktischer Fallback. Beide referenzieren dieselbe Party.
+
+### ADR-025 · Keine Party-Truhe
+**Status:** angenommen · 2026-09-04  
+**Kontext:** Früher war eine zusätzliche, mit Gruppengröße skalierende Truhe vorgesehen.  
+**Entscheidung:** Jede Person erhält individuelle normale Rewards; optional nur ein sehr kleiner additiver Goldbonus.  
+**Grund:** Solo darf wirtschaftlich nicht zur schlechteren Spielweise werden.
+
+### ADR-026 · Kein erstmaliger Drop-in in laufende Quest
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Neue Teilnehmer warten bis zum nächsten gemeinsamen Aufbruch. Reconnect bestehender Teilnehmer stellt die laufende Session wieder her.  
+**Grund:** Bewahrt Ready-Check-Ritual und vermeidet unklare Teilbelohnungen.
+
+### ADR-027 · Minimale, genderfreie Charaktererstellung
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Volk, Körperform, Haut-/Fantasyfarbe, Frisur, Haarfarbe, Name. Keine Geschlechtsauswahl und keine Detailregler.  
+**Grund:** Identität ohne unnötige Onboarding-Reibung; visuelle Optionen werden nicht künstlich nach Gender getrennt.
+
+### ADR-028 · Lager ist Home und Navigation
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Die Welt ist das Menü: Abenteuerbuch, Rucksack, Sammlung, Signalhorn und Händler leben im Lager. Settings bleiben konventionell erreichbar.  
+**Grund:** Das Produkt soll eine Fantasywelt sein, nicht ein SaaS-Dashboard mit Fantasy-Skin.
+
+### ADR-029 · Kuratierte Lager-Slots statt freiem Housing
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Dekoration über definierte Slots, keine freie Platzierung.  
+**Grund:** Personalisierung und sichtbare Geschichte ohne zweiten komplexen Spielmodus.
+
+### ADR-030 · XP und Gold haben getrennte Rollen
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** 1 tatsächlich fokussierte Minute = 1 XP. 1 Gold pro 5 erfolgreich abgeschlossenen Fokusminuten. Bei Abbruch bleiben XP, aber kein Questabschluss-Gold/keine Truhe.  
+**Grund:** Investierte Zeit bleibt wertvoll, Abschluss erhält trotzdem einen eigenen Reward.
+
+### ADR-031 · Erste Truhe ist deterministisch
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Erste 15-Minuten-Onboardingquest gibt einen kuratierten Lagerfund, z. B. die Alte Weglaterne.  
+**Grund:** Der erste Loop muss zuverlässig zeigen, dass reale Fokuszeit die Welt sichtbar verändert.
+
+### ADR-032 · Art Direction: lebendiges illustriertes Abenteuerbuch
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Adult Cozy Fantasy, 2D-Illustration mit leichter Diorama-/2.5D-Tiefe; nicht chibi, nicht fotorealistisch, nicht SaaS-Fantasy-Skin.  
+**Grund:** Ruhige Pen-&-Paper-Seele ist Teil der Produktidentität und unterstützt Fokus.
+
+### ADR-033 · Accessibility verändert niemals Progression
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Reduced Motion, Ruhiger Fokus, Timer-Ausblendung/-Vereinfachung und Audioeinstellungen haben keine Reward-Nachteile.  
+**Grund:** Zugänglichkeit ist Produktdesign, keine Schwierigkeitsstufe.
+
+### ADR-034 · No-Dark-Patterns-Charta
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Keine Streaks, Daily Rewards, Countdown-Shops, künstliche Verknappung, Schuldkommunikation, Vernachlässigung, Produktivitätsrankings oder bezahlte Lootboxen.  
+**Grund:** Das Produkt soll beim Fokussieren helfen und Aufmerksamkeit respektieren, nicht Retention durch Druck maximieren.
+
+### ADR-035 · Vertical Slice vor Feature-Breite
+**Status:** angenommen · 2026-09-04  
+**Entscheidung:** Zuerst den vollständigen Weg Waldintro → Account → Charakter → Lager → „Ein Licht im Unterholz“ → 15 Min → Abschluss → Rast → Weglaterne nahezu final umsetzen.  
+**Grund:** Erst die emotionale Kernhypothese beweisen, bevor Content- und Featurebreite ausgebaut werden.
+
+---
+
+## Superseded / nicht mehr gültig
+
+Folgende ältere Annahmen dürfen nicht mehr als Produktanforderung verwendet werden:
+- sechs Klassen oder klassenabhängige Timerprofile
+- epische Quest als 90-Minuten-Dauerblock
+- fünf Loot-Seltenheiten
+- Lootöffnung vor der Rast
+- lange Rast starr nach jeder vierten Quest
+- Party-Truhe
+- Dungeon-Master-Steuerung
+- erstmaliger Drop-in in eine laufende Quest
+- Streak-Anzeige
+- Charaktererstellung nur aus Volk + Name
+- Party-Code als einziger/primärer Einladungsweg
+- Charakterfähigkeiten oder Items mit Fokus-/Progressionsvorteilen
+
+Bei Konflikten mit älteren Dokumenten gilt [CONCEPT.md](CONCEPT.md).

--- a/docs/MOTION-ENGINE.md
+++ b/docs/MOTION-ENGINE.md
@@ -1,91 +1,152 @@
 # Bewegung und Grafik
 
-> Zuständigkeit: `#SENDEV` (Architektur) · `#junDev` (Umsetzung)
-> Entscheidungen: ADR-007 bis ADR-010 in [DECISIONS.md](DECISIONS.md)
+> Zuständigkeit: Architektur + Design/Frontend
+> Gilt zusammen mit [CONCEPT.md](CONCEPT.md), [ART-DIRECTION.md](ART-DIRECTION.md) und [ASSET-BIBLE.md](ASSET-BIBLE.md).
 
 ## Der Grundsatz
 
-**Animation bekommt keine eigene Uhr.**
+**Animation bekommt keine eigene fachliche Uhr.**
 
-```
-Position der Gruppe auf dem Weg  =  verstrichene Zeit / Quest-Dauer
-```
-
-Das ist dasselbe Prinzip wie beim Timer selbst — abgeleiteter Zustand statt laufender
-Schleife. Die Wanderung ist damit kein Zustand, der gepflegt werden muss, sondern ein
-Wert, der berechnet wird.
-
-Die Folgen sind der eigentliche Gewinn:
-
-| Situation | Verhalten |
-|---|---|
-| Tab 20 Minuten im Hintergrund | Beim Zurückkehren steht die Gruppe sofort an der richtigen Stelle |
-| Laptop-Standby über eine halbe Quest | Korrekt, ohne Aufholen |
-| Mitglied tritt bei Minute 17 bei | Sieht die Gruppe genau dort, wo sie ist |
-| Zwei Geräte derselben Party | Zeigen dieselbe Stelle des Weges, ohne einen einzigen Sync-Aufruf |
-
-Es kostet nichts, weil es auf demselben `requestAnimationFrame`-Tick mitläuft, der
-ohnehin den Timer zeichnet. Es gibt keine zweite Schleife.
-
-```ts
-// lib/timer/ — rein, ohne React, ohne Date.now()
-export function journeyProgress(phase: PartyPhase, now: number): number {
-  const elapsed = now - Date.parse(phase.phase_started_at)
-  return clamp01(elapsed / (phase.phase_duration_s * 1000))
-}
+```text
+Journey-Fortschritt = verstrichene Fokuszeit / Quest-Dauer
 ```
 
-## Was wir bewusst nicht laden
+Die Reise ist abgeleiteter Zustand. Dadurch ist sie nach Hintergrund-Tab, Standby, Reload oder Gerätewechsel sofort an der richtigen Stelle, ohne dass eine zweite Animations-Zeitachse synchronisiert werden muss.
 
-**Keine Game-Engine.** Phaser, PixiJS und Three.js sind hier die falsche Antwort.
+Bei Gruppenquests sehen wiederverbundene Mitglieder denselben Fortschritt. Ein erstmaliger Drop-in in eine bereits laufende Quest ist nach Concept V2 nicht vorgesehen.
 
-Ein WebGL-Canvas, der 50 Minuten am Stück rendert, ist genau das, was eine Fokus-App
-nicht tun darf: Er zieht Akku, lässt den Lüfter angehen und holt sich Aufmerksamkeit,
-die der Nutzer gerade woanders braucht. Dazu kämen 150–600&nbsp;kB Laufzeit für
-Fähigkeiten — Physik, Sprite-Batching, Szenengraph — von denen wir keine einzige nutzen.
+---
 
-Was wir tatsächlich brauchen, ist eine Kulisse, die sich sehr langsam bewegt, und
-**einen** Moment, der aufwendig ist. Dafür reichen SVG und CSS.
+## Keine Game Engine
 
-## Die drei Ebenen
+Phaser, PixiJS und Three.js sind für das Kernprodukt unnötig. Wir brauchen keine Physik, kein Echtzeit-Kampfsystem und keinen permanent rendernden Szenengraphen.
 
-| Ebene | Womit | Wo |
-|---|---|---|
-| **Ruhige Kulisse** | SVG-Ebenen, `transform: translateX`, gesteuert vom Fortschritt | Wanderung während der Quest, Lagerfeuer während der Rast |
-| **Übergänge** | `motion` (motion.dev), 120–600&nbsp;ms | Phasenwechsel, Panels, Listen |
-| **Der eine Moment** | **Rive**, State Machine | Truhe öffnen, Stufenaufstieg, Party-Truhe |
+Bevorzugt werden:
+- CSS für kleine Ambient-Effekte
+- SVG für einfache World-/UI-Elemente
+- `motion` für Übergänge und leichte Transforms
+- zeitabhängige Layer-/Szenenwechsel für Quest-Journeys
+- Rive nur dort, wo eine echte State-Machine-Animation einen klaren Mehrwert hat
 
-### Warum Rive für die Truhe
+Die Fokusphase soll CPU- und akkusparend bleiben.
 
-Die Truhe hat fünf Seltenheitsstufen. Handanimiert wären das fünf Varianten derselben
-Choreografie, die auseinanderlaufen, sobald jemand eine davon anfasst.
+---
 
-Rive löst das über eine **State Machine**: ein Asset, ein Eingang `rarity` (0–4), und
-die Übergänge gehören zur Datei statt zum Code. Eine Designerin ändert das Timing, ohne
-dass jemand ein Deployment braucht.
+## Ebenenmodell
 
-Der Preis ist ehrlich zu nennen: rund 200&nbsp;kB WASM und die Voraussetzung, dass
-jemand im Team den Rive-Editor bedient. Deshalb ist Rive **nur** für die Höhepunkte
-vorgesehen — nicht für Übergänge, nicht für die Kulisse, nicht für Icons.
+Ein Quest- oder Lagerbild kann aus mehreren 2D-Ebenen bestehen:
 
-**Ladeverhalten:** Die Rive-Laufzeit wird erst geladen, wenn die erste Quest fast
-vorbei ist (`progress > 0.9`), nicht beim Seitenaufruf. Wer die App öffnet, um zu
-arbeiten, soll keine Animationslaufzeit herunterladen.
+1. Hintergrund
+2. Mittelgrund
+3. Vordergrund
+4. Charakter(e)
+5. atmosphärische Ebene (Nebel, Licht, Blätter, Glut)
+6. UI
 
-**Fallback ist Pflicht, nicht Kür:** Lädt Rive nicht, öffnet sich die Truhe als
-CSS-Überblendung mit demselben Ergebnis. Dieselbe Fassung dient unter
-`prefers-reduced-motion`.
+Die Ebenen dürfen sich mit unterschiedlichen, sehr kleinen Geschwindigkeiten bewegen. Bewegung bleibt unterstützend und nie aufmerksamkeitsfordernd.
 
-## Budget
+---
 
-Verbindlich, wird in CI geprüft:
+## Journey-Beats
 
-| | |
-|---|---|
-| JavaScript auf dem Quest-Screen | ≤ 120&nbsp;kB gzip, **ohne** Rive |
-| Rive-Laufzeit | nachgeladen, nie im ersten Bundle |
-| Bilder im Erstaufruf | ≤ 250&nbsp;kB |
-| CPU während einer laufenden Quest | < 2&nbsp;% auf einem Laptop von 2020 |
+Questtypen können unterschiedliche Beat-Zahlen haben:
+- Kundschaftergang 15 min: ca. 3–4 Zustände
+- Kurze Quest 25 min: ca. 4 Zustände
+- Mittlere Quest 50 min: ca. 5 Zustände
+- Epische Quest: pro 25-Minuten-Akt eigene Zustände; Arc-Fortschritt bleibt über Akte persistent
 
-Der letzte Punkt ist der wichtigste und der einzige, den man nicht messen kann, ohne
-es zu versuchen. Er gehört in jedes Review eines Animations-PRs.
+Ein Beat ist kein zwingend komplett neues Vollbild. Oft reicht ein anderer Vordergrund, Lichtzustand, Questdetail oder Ausschnitt derselben Region.
+
+---
+
+## Aufbruch
+
+Aufbruch ist ein 3–5 Sekunden langes Ritual:
+- Charakter richtet sich auf / nimmt Ausrüstung
+- Scene/Audio wechselt
+- kurze Kamerabewegung oder Überblendung
+- Fokuszeit beginnt
+
+Reduced Motion: statischer Zustandswechsel mit kurzer Überblendung.
+
+---
+
+## Fokusphase
+
+Während Fokus gilt:
+- keine hektischen Animationen
+- keine dauernden UI-Pulse
+- keine Bildschirmerschütterungen
+- keine Action-Choreografie, die Aufmerksamkeit verlangt
+- keine nötige Interaktion
+
+Ambient Motion darf laufen, muss aber klein und pausierbar sein.
+
+### Ruhiger Fokus
+Im Modus „Ruhiger Fokus“ werden Szenenwechsel und Ambient Motion weiter reduziert. Die fachliche Journey und Rewards bleiben unverändert.
+
+---
+
+## Questabschluss
+
+Der Questabschluss ist kurz, eindeutig und wärmer/größer als die Fokusphase:
+- Zielzustand der Szene
+- musikalische Auflösung
+- XP/Gold/Truhe verdient
+- Übergang zur Rast
+
+Die Truhe wird **nicht vor der Rast geöffnet**.
+
+---
+
+## Rast
+
+Rast ist der visuell ruhigste Zustand:
+- keine Journey-Bewegung
+- Feuer/Umgebung nur subtil
+- Musik stark reduziert oder aus
+- eine optionale kleine Handlung
+- aktive Einladung, den Bildschirm zu verlassen
+
+---
+
+## Truhe
+
+Die Truhe ist ein hochwertiger Discovery-Moment nach der Rast.
+
+Rive ist möglich, aber nicht verpflichtend. Wenn Rive eingesetzt wird, muss:
+- die Runtime lazy geladen werden
+- die Animation alle vier Seltenheiten unterstützen
+- ein CSS-/statischer Fallback existieren
+- Reduced Motion einen gleichwertigen Endzustand erhalten
+
+Keine Party-Truhe. Gruppenmitglieder erhalten individuelle Rewards.
+
+---
+
+## Reduced Motion
+
+`prefers-reduced-motion` wird respektiert und durch eine In-App-Einstellung ergänzt.
+
+Reduziert/entfernt werden insbesondere:
+- Parallax
+- große Kamerafahrten
+- Zooms
+- starke Transform-Animationen
+
+Atmosphäre bleibt über Illustration, Licht und sanfte Fades erhalten.
+
+---
+
+## Performance-Leitplanken
+
+- keine Game Engine im Quest-Screen
+- große World-Assets responsive und komprimiert ausliefern
+- nur aktuelle Region und nächste Beats priorisiert laden
+- Audio erst bei Bedarf und nach Nutzerinteraktion laden
+- Hero-Motion-Runtimes nie in den initialen Bundle-Pfad zwingen
+- Animation darf Fokusfunktion nie blockieren
+
+Die konkreten Assetformate, Layer-Konventionen und Produktionsschritte stehen in [ASSET-BIBLE.md](ASSET-BIBLE.md).
+
+> **Wenn Motion ausfällt, muss der Timer trotzdem perfekt funktionieren.**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,40 +1,141 @@
-# Roadmap
+# Roadmap – Concept V2
 
-Jeder Meilenstein existiert als GitHub-Milestone. Aufgaben liegen als Issues darunter.
+> Reihenfolge folgt der Produkthypothese: **erst beweisen, dass die Solo-Fokusreise emotional funktioniert; dann Tiefe und Multiplayer ergänzen.**
 
-Reihenfolge nach der Entscheidung zu K3 (Issue #28): **Solo ist der Normalzustand**,
-die Gruppe kommt danach. Eine Gruppenfunktion ohne Lager hätte keinen Ort, an dem sie
-stattfindet — das Signalhorn steht im Lager.
+Die verbindlichen Produktentscheidungen stehen in [CONCEPT.md](CONCEPT.md). Diese Roadmap beschreibt nur die Umsetzungsreihenfolge.
 
-## M0 · Draft & Freigabe ← **hier stehen wir**
-Konzept, Architektur, Sync-Protokoll, Design-System und der Abgleich mit Konzept V1
-liegen vor. **Offen:** K10 (Ton der Quests, #31), K11 (90 Minuten, #32), Produktname.
+## Phase 0 · Concept V2 & Konsolidierung
 
-## M1 · Fundament `#SENDEV`
-Next.js, Tailwind, shadcn/ui, Design-Tokens, Supabase, Migrationen, RLS, CI.
+- Concept V2 als Source of Truth
+- widersprüchliche Alt-Dokumentation markieren bzw. migrieren
+- vorhandene Quest-, Loot-, Journey- und Sync-Logik gegen Concept V2 prüfen
+- technische Grundlagen nicht neu erfinden, wenn vorhandene Implementierung kompatibel ist
 
-## M2 · Lager und Solo-Schleife `#SENDEV` `#junDev`
-Das Lager als Hub — „die Welt ist das Menü". Abenteuerbuch mit Wochenpool,
-Charaktererstellung (Volk + Name), `lib/timer/` als reine Logik, Quest, Rast, Wanderung.
-**Abnahme:** Man kann sich anmelden, einen Charakter anlegen, eine Quest wählen, sie
-absolvieren und zurück ins Lager kommen — allein, ohne dass irgendwo eine Gruppe nötig wäre.
+**Abnahme:** Neue Entwicklung kann eine Produktfrage eindeutig aus `CONCEPT.md` beantworten.
 
-## M3 · Progression `#SENDEV` `#junDev`
-XP, Level, Gold, Truhen mit der Keine-Duplikate-Ziehung, Item-Katalog, Sammlungssets,
-Inventar, erste Lager-Ausbaustufen.
-**Abnahme:** Fokuszeit erzeugt sichtbaren Fortschritt an Charakter **und** Lager.
+---
 
-## M4 · Gruppe `#SENDEV`
-Signalhorn im Lager, Party-Codes, Bereitschaftsprüfung, Broadcast, Presence,
-Clock-Skew-Abgleich. Gefährten sitzen sichtbar am Feuer.
-**Abnahme:** alle Testfälle aus [SYNC-PROTOCOL.md](SYNC-PROTOCOL.md) grün.
+## Phase 1 · Vertical Slice
 
-## M5 · Release `#release`
-Barrierefreiheits-Durchgang, Performance-Budget, Landing Page, Impressum und
-Datenschutzerklärung, Datenexport und Kontolöschung, Domain `pomodoro.lang-jamin.de`,
-Monitoring. **Abnahme:** Freigabe durch das Release Team.
+Ein einziger, nahezu final wirkender Nutzerweg:
 
-## M6 · Artwork `#junDev`
-Illustrierte Items, Rive-Animationen, acht Regionen-Kulissen, Lager-Ausbaustufen.
-Läuft ab M2 parallel, blockiert nichts — der Item-Baukasten liefert vom ersten Tag an
-vollwertige Liniengrafiken.
+**Waldintro → Account → Charakter → kleines Lager → Abenteuerbuch → „Ein Licht im Unterholz“ → 15 Minuten Fokus → Questabschluss → Rast → deterministische Weglaterne → sichtbare Veränderung im Lager**
+
+Enthalten:
+- responsive Web-Grundlage
+- minimale Charaktererstellung: Volk, Körperform, Haut-/Fantasyfarbe, Frisur, Haarfarbe, Name
+- Lager als Hub
+- integrierter, serverzeitfähiger Timer
+- ruhige 2D-Journey
+- Aufbruchs- und Abschlussritual
+- XP/Gold
+- Rast vor Truhe
+- deterministischer erster Lootfund
+- Basis-Audio
+- Reduced Motion / Timerdarstellung / Mute
+
+**Abnahme:** Der komplette erste 15-Minuten-Loop fühlt sich wie das Zielprodukt an und beweist die emotionale Kernhypothese.
+
+---
+
+## Phase 2 · Core MVP
+
+Den Vertical Slice zu einer regelmäßig nutzbaren Solo-App ausbauen.
+
+Enthalten:
+- nachfüllendes Abenteuerbuch
+- 15/25/50-Minuten-Quests
+- mehrere Regionen
+- persistente laufende Quests und Gerätewechsel
+- XP- und Levelsystem
+- Gold
+- Truhen und No-Duplicate-Loot
+- vier Seltenheitsstufen 60/27/11/2
+- kosmetische Ausrüstung / freigeschaltete Looks
+- Inventar / Sammlung-Grundlage
+- erste Lagerprogression
+- Settings und Accessibility vollständig für den MVP
+- responsive Desktop-/Mobile-Komposition
+
+**Abnahme:** Solo kann dauerhaft genutzt werden, ohne Party oder spätere Metasysteme zu benötigen.
+
+---
+
+## Phase 3 · Weltvertiefung
+
+- Händlerwagen und kosmetische Gold-Economy
+- thematische Sets
+- Set-Abschlussbelohnungen
+- weitere Regionen und Questinhalte
+- kuratierte Lager-Dekorationsslots
+- Lagerstufen: Kleines Lager → Reiselager → Abenteurerlager → Außenposten
+- besondere Quest-Erinnerungen
+- erster Begleiter und weitere Meilensteinmomente
+
+**Abnahme:** Langfristiger Fortschritt wird im Lager sichtbar und erzählt persönliche Geschichte, ohne Power-Progression zu erzeugen.
+
+---
+
+## Phase 4 · Gemeinsam aufbrechen
+
+Solo bleibt unverändert vollständig.
+
+Enthalten:
+- Signalhorn im Lager
+- Einladungslink als Standard
+- kurzer Party-Code als Fallback
+- Account + Charakter verpflichtend
+- optional „als Gefährten merken“ nach gemeinsamer Quest
+- Bereitschaftsprüfung, kein Dungeon Master
+- gemeinsame serverbasierte Uhr
+- gemeinsame passive Journey
+- kein Chat / keine Pings / keine Reactions während Fokus
+- individueller Abbruch
+- individuelle Rewards und Truhen
+- optional kleiner additiver Goldbonus
+- **keine Party-Truhe**
+- kein erstmaliger Drop-in in eine laufende Quest; Reconnect bleibt möglich
+
+**Abnahme:** Mehrere Personen können gemeinsam aufbrechen und synchron fokussieren, ohne dass Multiplayer Voraussetzung, Ablenkung oder Verpflichtung wird.
+
+---
+
+## Phase 5 · Epische Abenteuer
+
+- 3 × 25 Minuten als ein erzählerischer Bogen
+- Rast zwischen den Akten
+- persistenter Aktfortschritt über Tage
+- Boss / Höhepunkt in Akt III
+- stärkere, aber weiterhin fokusfreundliche Inszenierung
+
+**Abnahme:** Ein episches Abenteuer kann unterbrochen und später fortgesetzt werden, ohne Fortschrittsverlust oder FOMO.
+
+---
+
+## Phase 6 · Langfristige Welt
+
+Mögliche Erweiterungen:
+- weitere Begleiter
+- neue Setlinien
+- zusätzliche Regionen
+- besondere Welt-/Lagerereignisse
+- zusätzliche langfristige Meilensteine
+- PWA-Verbesserungen und spätere Plattformoptionen
+
+Neue Systeme müssen weiterhin die No-Dark-Patterns-Charta aus `CONCEPT.md` erfüllen.
+
+---
+
+## Technische Leitplanken über alle Phasen
+
+- Web first, responsive von Beginn an
+- serverseitige Account-Persistenz
+- Timer als Zeit-/Sessionzustand, nicht als lokaler Countdown
+- Journey als aus verstrichener Zeit abgeleiteter Zustand
+- datengetriebener Content
+- Fokuszeit bei Fehlern schützen
+- progressive Asset-Ladung
+- Accessibility von Beginn an
+- keine Game Engine ohne neue, belegte Notwendigkeit
+
+**Oberste Regel:** Die Fokuszeit der Person ist heiliger als die Spielinszenierung.

--- a/docs/SCREENS.md
+++ b/docs/SCREENS.md
@@ -1,132 +1,297 @@
-# Screens
+# Screens & User Journey – Concept V2
 
-> Der visuelle Draft liegt als Claude-Design-Canvas vor (Link im Issue
-> `#release Design-Draft Review`). Diese Seite ist die textliche Referenz dazu.
+> Textliche UX-Referenz. Produktentscheidungen kommen aus [CONCEPT.md](CONCEPT.md). Die Welt ist das Menü; konventionelle UI wird dort eingesetzt, wo sie Verständlichkeit oder Accessibility verbessert.
 
-Reihenfolge entspricht dem Nutzerweg — von der Tavernentür bis zum Charakterbogen.
+## 1 · Erster Eintritt (`/`)
+
+**Modus: Welt betreten, nicht Marketing konsumieren.**
+
+Ruhige Waldszene, entferntes warmes Licht.
+
+> „Ah. Da bist du ja.“
+>
+> „Wir haben noch einen Platz am Feuer.“
+
+Primäre Aktion: **Zum Lager**.
+
+Kein laufender Demo-Timer, keine Klassenwerbung, kein Party-Code-Feld als dominanter Einstieg.
 
 ---
 
-## 1 · Landing (`/`)
-**Modus: Überzeugen.** Öffentlich, unter `pomodoro.lang-jamin.de`.
+## 2 · Login / Account (`/login`)
 
-Erklärt das Produkt in einem Bildschirm: die Quest-Metapher, die Klassen und das
-Party-Feature. Der Beweis ist ein **echter, laufender Timer** in der Hero-Fläche —
-kein Screenshot, kein Video. Wer die Seite öffnet, sieht das Produkt arbeiten.
+So wenig Reibung wie möglich. Account ist nötig für Charakter, Fortschritt und Gerätewechsel.
 
-Zwei Handlungsangebote, klar gewichtet: *Quest beginnen* (primär) und
-*Party beitreten* mit direktem Code-Feld (sekundär, aber sofort bedienbar). Der
-häufigste Besucher hat einen Code von einer Freundin bekommen — der darf nicht
-hinter einem Login liegen.
+Copy-Prinzip: Grund erklären statt Registrierung verkaufen, z. B. **„Damit dein Lager dich wiederfindet.“**
 
-## 2 · Login (`/login`) — „Die Tavernentür"
-Zwei Wege:
+Kein Gastzugang.
 
-1. **Discord** — die Zielgruppe hat dort schon einen Account.
-2. **Magic Link** per E-Mail — kein Passwort, das jemand vergessen kann.
+Zustände: lädt · Anmeldung versendet/gestartet · abgelaufen/abgebrochen · offline · Fehler.
 
-**Kein Gastzugang.** Konto und Charakter sind Pflicht, damit Fortschritt, Inventar und
-Level geräteübergreifend erhalten bleiben (Entscheidung zu W5, Issue #30).
+---
 
-Weil das die härteste Hürde der App ist und direkt vor dem ersten Erlebnis steht, trägt
-dieser Screen die entsprechende Verantwortung: kein Passwort, keine Bestätigungsmail vor
-dem Betreten, und der Text sagt, **warum** — nicht „Registrieren", sondern „Damit dein
-Charakter dir auf jedem Gerät folgt."
+## 3 · Charaktererstellung (`/character`)
 
-Zustände: `lädt` · `Magic Link verschickt` · `Link abgelaufen` · `OAuth abgebrochen`
-· `offline`.
+Fünf Völker: **Mensch · Elf · Zwerg · Goblin · Ork**.
 
-## 3 · Charakter (`/character`)
-**Fünf Völker:** Mensch, Elf, Zwerg, Goblin, Ork. Dazu ein Name.
+Keine Klassen und keine Geschlechtsauswahl.
 
-Die Wahl ist **Identität, keine Mechanik**. Sie bringt keine Fähigkeiten und keine
-Zeiten mit — besondere Fähigkeiten werden später *erspielt*, nicht gewählt
-(Entscheidung zu K1, Issue #27). Der Charakter bleibt dauerhaft, geht auf alle Quests
-und levelt.
+V1-Auswahl:
+- Volk
+- Körperform / Silhouette
+- Haut-/Fantasyfarbe
+- Frisur
+- Haarfarbe
+- Name
 
-Weil die Karten damit nichts Zählbares mehr zeigen, tragen sie das Volk selbst: Figur,
-eine Zeile Charakter, sonst nichts. Kein Raster gleich großer Icon-Karten — die gewählte
-Figur wird groß und steht neben dem Namensfeld.
+Keine Detailregler, Tattoos, Narben, Patches oder Make-up-Systeme.
 
-**Die Dauer hängt nicht mehr hier, sondern an der Quest.** Man wählt „Der verlassene
-Wachtturm · Mittlere Quest · 50 Minuten" im Abenteuerbuch — und das ist die Einstellung.
+Figur groß im Mittelpunkt, Änderungen live sichtbar. Nach Namensvergabe kein Success-Dialog; der Charakter geht direkt ins Lager.
 
-## 4 · Quest läuft (`/quest`) — Hauptscreen
-Der Bildschirm, den man 25 Minuten lang ansieht. Deshalb: **ruhig**.
+---
 
-- Der Timer beherrscht die Fläche. Große Ziffern, `tabular-nums`, Messing auf warmem
-  Schwarz.
-- Ein Fortschrittsring als Fassung — die einzige Ornamentik.
-- Darunter klein: welche Quest im Zyklus (2 von 4), die Klasse, der Streak.
-- Steuerung: *Pausieren* und *Aufgeben*. Mehr nicht. Alles Weitere liegt hinter einem
-  Menü und stört den Fokus nicht.
-- Auto-DND-Status als schlichte Zeile, nicht als Banner.
+## 4 · Lager (`/camp`)
 
-Zustände: `läuft` · `pausiert` · `letzte Minute` (der Ring wechselt die Farbe,
-kein Blinken) · `abgeschlossen`.
+**Home-Screen und zentraler Hub.** Leicht erhöhte 2D-Diorama-Perspektive.
 
-## 5 · Rast (`/quest` — Pausenphase)
-Sichtbar anderer Ort. Warme Ember-Töne statt Messing, ein Lagerfeuer mit ruhiger
-Atem-Animation (4 s, unter `reduce` stillstehend).
+Diegetische Objekte:
+- Abenteuerbuch → Quests
+- Charakter / Rucksack → Ausrüstung
+- Sammlung → Sets/Funde
+- Signalhorn → Gefährten/Party
+- Händlerwagen → kosmetische Goldkäufe
 
-Der Text lädt zur Pause ein, statt sie zu überwachen: „Deine Gruppe rastet. Steh auf,
-trink was." Der *Rast überspringen*-Button existiert, ist aber sekundär — Pausen zu
-überspringen ist der häufigste Fehler beim Pomodoro.
+Settings bleiben als dezentes konventionelles Zahnrad verfügbar.
 
-## 6 · Truhe (`/quest` — nach der Quest)
-**Der Moment.** Die Truhe erscheint mittig, das Umfeld tritt zurück.
+Erstes Lager ist bereits gemütlich: Feuer, einfacher Schlafplatz, Buch, Rucksack, Horn. Spätere Entwicklung macht es reicher und persönlicher, nicht erst „schön“.
 
-Öffnen ist eine bewusste Handlung — Klick, Leertaste oder Enter. Dann die
-Choreografie: Ruck, Riss, Lichtschein in der Seltenheitsfarbe, Inhalt steigt auf,
-Zahlen zählen hoch (`tabular-nums`, damit nichts zappelt).
+Auf Mobile wird die Szene neu komponiert statt nur verkleinert.
 
-Unter `prefers-reduced-motion` gibt es dieselbe Belohnung als Überblendung — gleicher
-Inhalt, gleicher Beat, keine Bewegung. Ungeöffnete Truhen wandern ins Inventar und
-gehen nicht verloren.
+---
 
-## 7 · Party-Hub (`/party`)
-Zwei gleichwertige Hälften: **Party gründen** und **Party beitreten**.
+## 5 · Abenteuerbuch (`/quests`)
 
-Beim Gründen erscheint der Code groß und gesperrt gesetzt — `H 2 6 H E` — mit einem
-Kopieren-Button, der den Erfolg auch bestätigt.
+Illustriertes Journal statt SaaS-Kartenraster.
 
-Beim Beitreten ein Fünf-Zeichen-Feld: Einfügen erlaubt, Groß-/Kleinschreibung egal,
-`I`/`L`→`1` und `O`→`0` werden automatisch gemappt. Fehlermeldung nennt den nächsten
-Schritt, nicht nur das Problem.
+Quest auf einen Blick:
+- Name
+- Region
+- Typ
+- **Dauer prominent**
+- kurzer Hook
 
-## 8 · Party-Quest (`/party/[code]`)
-Derselbe ruhige Timer wie im Solo-Modus — **eine Uhr, die für alle gilt** — plus die
-Mitgliederliste seitlich.
+Lesezeichen/Filter: **15 · 25 · 50 · Episch**.
 
-Jedes Mitglied: Name, Klassen-Sigel, Status (unterwegs / rastet / weg). Der Dungeon
-Master ist markiert; nur er sieht die Steuerung, alle anderen sehen an ihrer Stelle,
-wer steuert.
+Der Pool hält ungefähr zehn Optionen sichtbar und füllt sich nach; keine Fristen oder Ablaufkommunikation.
 
-Zustände, die gestaltet sein müssen: `wartet auf Start` · `ein Mitglied` ·
-`zwölf Mitglieder` · `Mitglied verbindet neu` · `DM hat verlassen, Rolle wandert` ·
-`eigene Verbindung weg` (deutlicher Hinweis — die angezeigte Zeit könnte veraltet sein).
+Questdetail zeigt Illustration/Atmosphäre, 1–2 Erzählerzeilen, Dauer und Grundbelohnungen.
 
-## 9 · Charakterbogen (`/character/sheet`)
-Kein Dashboard voller Kacheln. Ein **Bogen**: Klasse, Stufe, XP-Balken, Gold,
-Streak-Tage, absolvierte Quests, Inventar der Fundstücke.
+Aktionen: **Alleine aufbrechen** · **Gefährten rufen** (sobald Party verfügbar ist).
 
-Die Fokus-Historie als schlichte Wochenansicht — informativ, ohne Druck zu erzeugen.
-Es gibt bewusst keine roten Lücken für ausgelassene Tage.
+Kein Pflichtfeld „Woran möchtest du arbeiten?“.
 
-## 10 · Einstellungen (`/settings`)
-Eigene Zeiten, Ton, Systembenachrichtigungen, Auto-DND, Design (Dunkel / Hell /
-System), Bewegung reduzieren, Sprache. Dazu Datenexport und Kontolöschung — sichtbar,
-nicht versteckt.
+---
+
+## 6 · Aufbruch
+
+Kurze 3–5-Sekunden-Sequenz. Charakter steht auf, nimmt Ausrüstung, Musikmotiv beginnt, Szene wechselt. Danach startet die Fokuszeit.
+
+---
+
+## 7 · Quest läuft (`/quest/[session]`)
+
+**Hauptscreen. Ruhig, illustrativ, lesbar.**
+
+- dominante 2D-Questlandschaft
+- Questname
+- integrierter exakter Timer, standardmäßig z. B. `18:42`
+- atmosphärischer Reise-/Fortschrittsindikator
+- Pause
+- Audio
+- optional Vollbild
+- Quest verlassen
+
+Der Timer ist Teil der Abenteuerwelt, aber funktional sofort lesbar. Kein riesiger generischer Digitaltimer als Overlay.
+
+Timer-Modi:
+- exakt
+- ungefähr („Noch etwa 20 Minuten“)
+- atmosphärisch (nur Journey-Fortschritt)
+
+Während Fokus kein Inventar, Händler, Sammlung, Chat, Pings oder klickbare Spielmechanik.
+
+Zustände: läuft · pausiert · offline/reconnecting · abgeschlossen.
+
+---
+
+## 8 · Questabschluss
+
+Die Szene erreicht ihr Ziel; Aufbruchsmotiv löst sich musikalisch auf. Kein schriller Beep.
+
+Anzeige:
+
+**Quest abgeschlossen**
+
+`+ XP` · `+ Gold`
+
+**Eine Truhe wartet auf dich.**
+
+Die Truhe wird jetzt noch nicht geöffnet.
+
+---
+
+## 9 · Rast (`/quest/[session]/rest` oder Session-State)
+
+Charakter am Feuer. Optional eine einzige kleine Handlung wie **Holz nachlegen**.
+
+Danach:
+
+> „Das Feuer hält. Geh ruhig. Wir passen hier auf.“
+
+Keine Minispiele, kein Händler, keine Sammlung, kein Lootmenü.
+
+Kurze Rast ca. 5 Minuten. Lange Rast wird später anhand kumulierter Fokuszeit empfohlen, nicht nach starrer Questanzahl.
+
+Rast überspringen ist erlaubt und ohne Strafe.
+
+---
+
+## 10 · Truhe
+
+Erst nach der Rast bzw. nach bewusstem Überspringen.
+
+> „Während du weg warst, hat sich die Truhe leider nicht selbst geöffnet.“
+
+Aktionen: **Truhe öffnen** · **Später**.
+
+Öffnung wirkt materiell und hochwertig, nicht wie Slotmachine. Reduced Motion zeigt denselben Inhalt ohne große Bewegung.
+
+Wenn ein Item enthalten ist, ist es neu. Gefundene Ausrüstung wird nicht automatisch angelegt.
+
+Erste Truhe im Onboarding ist deterministisch: **Alte Weglaterne** (oder final benannter äquivalenter Lagerfund). Danach sichtbare Platzierung im Lager.
+
+---
+
+## 11 · Sammlung
+
+Wird erst nach dem ersten relevanten Fund eingeführt.
+
+Thematische Sets statt generischer Itemlisten, z. B. **Relikte des Flüsterwaldes · 3/5**. Unbekannte Teile als Silhouetten/Hinweise.
+
+---
+
+## 12 · Händler
+
+Erscheint nach frühen Fortschritten als Welt-Ereignis und bleibt danach im Lager.
+
+Nur kosmetische Waren gegen Gold. Keine Countdown-Angebote, keine dauerhafte künstliche Verknappung.
+
+---
+
+## 13 · Charakter / Ausrüstung
+
+Kein klassischer RPG-Charakterbogen mit Stats oder Streak.
+
+Zeigt:
+- Charakter und Level
+- XP / kumulativen Fortschritt
+- Gold
+- kosmetische Ausrüstung
+- freigeschaltete Looks
+- neutrale Fokus-/Questhistorie, sofern später vorgesehen
+
+Keine Power-Werte und keine roten „verpassten Tage“.
+
+---
+
+## 14 · Signalhorn / Party
+
+Das Signalhorn öffnet die soziale Ebene aus dem Lager heraus.
+
+Standard: **Einladungslink teilen**. Zusätzlich kurzer Party-Code als Fallback.
+
+Kein Freundschafts-Handshake vor der ersten Session. Nach gemeinsamer Quest optional: **Als Gefährten merken**.
+
+Konto und Charakter sind Pflicht.
+
+---
+
+## 15 · Party wartet
+
+Alle sehen vorgeschlagene Quest, Dauer und Bereitschaft.
+
+Beispiel:
+- Daisy — bereit ✓
+- Benny — bereit ✓
+- Juliette — noch nicht bereit
+
+Kein Dungeon Master und kein automatischer Countdown. Start erst nach Bereitschaft aller aktuellen Mitglieder.
+
+---
+
+## 16 · Party-Quest
+
+Dieselbe Fokusoberfläche wie solo, zusätzlich die gemeinsam reisenden Charaktere. Eine gemeinsame serverbasierte Uhr.
+
+Während Fokus:
+- kein Chat
+- keine Emojis
+- keine Pings
+- keine Reactions
+
+**Zusammen allein.**
+
+Individueller Abbruch beendet die Quest nicht für andere.
+
+Erstmaliger Beitritt während einer laufenden Quest ist nicht möglich; der Screen zeigt, dass die Gruppe unterwegs ist und bei der nächsten Quest gemeinsam aufbrechen kann. Reconnect eines bestehenden Teilnehmers stellt die laufende Session wieder her.
+
+Abschluss: individuelle XP/Gold/Truhen; keine Party-Truhe. Optional kleiner additiver Goldbonus.
+
+---
+
+## 17 · Einstellungen (`/settings`)
+
+Bewusst konventionell und klar:
+- Account
+- Timerdarstellung
+- Ruhiger Fokus
+- Reduced Motion
+- Musik
+- Umgebung
+- Effekte
+- alles stummschalten
+- Accessibility
+- später Benachrichtigungen
+- Datenexport / Kontolöschung
+
+Keine Fantasy-Metapher, wenn sie Bedienbarkeit verschlechtert.
+
+---
+
+## 18 · Rückkehr / laufende Quest auf anderem Gerät
+
+Wenn eine Session läuft, wird sie wiederhergestellt:
+
+> „Du bist noch unterwegs.“
+
+Restzeit wird aus dem autoritativen Sessionzustand rekonstruiert, nicht lokal neu gestartet.
+
+Nach langer Abwesenheit kein Recovery-/Schuld-Screen. Lager bleibt unverändert.
 
 ---
 
 ## Für jeden Screen verbindlich
 
-| | |
+| Prinzip | Regel |
 |---|---|
-| Zustände | leer · lädt · Fehler · offline — keine Ausnahme |
-| Tastatur | vollständig bedienbar, sichtbarer Fokusring |
-| Responsiv | 360 px bis 1920 px, ohne horizontales Scrollen |
-| Themes | dunkel **und** hell, beide geprüft |
-| Texte | Problem **und** nächster Schritt bei jedem Fehler |
-| URL | Zustand steckt in der URL — Party-Code ist teilbar |
+| Zustände | leer · lädt · Fehler · offline/reconnect, wo relevant |
+| Tastatur | Kernfunktionen vollständig bedienbar, sichtbarer Fokus |
+| Semantik | diegetisch visuell, semantisch darunter |
+| Responsive | Mobile neu komponieren, nicht Desktop nur schrumpfen |
+| Farbe | Status nie ausschließlich über Farbe |
+| Audio | wichtige Information nie ausschließlich akustisch |
+| Motion | `prefers-reduced-motion` + In-App Reduced Motion |
+| Fokus | keine unnötige Interaktion während laufender Quest |
+| Copy | warm, kurz, klar; Fehler nennen Problem und nächsten Schritt |
+
+**Informationshierarchie:** Verständlichkeit → Fokus → Atmosphäre → dekorativer Detailreichtum.


### PR DESCRIPTION
## Ziel
Concept V2 als verbindliche Source of Truth im Repository verankern und die zentralen Produktdokumente auf die gemeinsam beschlossenen Entscheidungen ausrichten.

## Geändert
- `docs/CONCEPT.md`: vollständige Concept-V2-Spezifikation mit Vision, Lager, Gameplay, Progression, Charakteren, Party, UX, Art/Audio, Accessibility und MVP
- `README.md`: veraltete Klassen-/90-Minuten-/Party-Truhen-Beschreibung entfernt und Source-of-Truth-Hierarchie eingeführt
- `docs/SCREENS.md`: User Journey auf Lager-Hub, integrierten Timer, Rast-vor-Truhe, progressive Discovery und neue Party-UX umgestellt
- `docs/ROADMAP.md`: Vertical Slice → Core MVP → Weltvertiefung → Party → Epic → langfristige Welt
- `docs/DECISIONS.md`: widersprechende Altentscheidungen superseded und neue Concept-V2-ADRs dokumentiert

## Zentrale Produktentscheidungen
- fünf Völker, keine Klassen, keine mechanischen Builds
- keine Geschlechtsauswahl; minimale modulare Charaktererstellung
- Lager ist Home und Navigation: „Die Welt ist das Menü“
- 15/25/50 Minuten; Epic = 3×25 mit Rasten
- 1 Fokusminute = 1 XP; Gold separat als Wahlwährung
- vier Seltenheiten 60/27/11/2; keine Item-Duplikate
- Questabschluss → Rast → Truhe
- deterministischer erster Fund / Weglaterne
- Solo vollständig; Party optional
- Einladungslink primär, kurzer Code als Fallback
- Ready Check, kein Dungeon Master
- keine Party-Truhe und kein erstmaliger Drop-in in laufende Quests
- Adult Cozy Fantasy / lebendiges illustriertes Abenteuerbuch
- Accessibility ohne Reward-Nachteile
- verbindliche No-Dark-Patterns-Charta

## Scope
Dieser PR konsolidiert zunächst die **Produktdokumentation**. Bestehende Content-/Core-Logik wird nicht blind verworfen; technische und inhaltliche Implementierungsdetails, die noch gegen Concept V2 laufen, können auf dieser eindeutigen Source of Truth anschließend gezielt migriert werden.

## Diff
5 Dokumente geändert; Branch basiert direkt auf `main` und ist aktuell 5 Commits voraus.