### PR TITLE
feat: minimale Charaktererstellung für Phase 1

### DIFF
--- a/app/character/character-creator.tsx
+++ b/app/character/character-creator.tsx
@@ -191,8 +191,8 @@ export function CharacterCreator({ userId, initialCharacter }: { userId: string;
 
 function CharacterPreview({ draft, asset }: { draft: CharacterDraft; asset: string }) {
   const bodyScale = bodyScales[draft.bodyVariant] ?? 1
-  const skinColor = skinColors[draft.skinVariant] ?? skinColors.warm
-  const hairColor = hairColors[draft.hairColor] ?? hairColors.dunkel
+  const skinColor = skinColors[draft.skinVariant] ?? '#c8a483'
+  const hairColor = hairColors[draft.hairColor] ?? '#49392f'
 
   return (
     <svg className={styles.characterPreview} viewBox="0 0 512 512" focusable="false">

--- a/app/character/character-creator.tsx
+++ b/app/character/character-creator.tsx
@@ -1,0 +1,197 @@
+'use client'
+
+import { FormEvent, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createSupabaseBrowserClient } from '../../lib/supabase/client'
+import styles from './character.module.css'
+
+const ancestries = [
+  { id: 'mensch', label: 'Mensch', asset: 'race-human-base', note: 'Findet überall einen Weg hinein' },
+  { id: 'elf', label: 'Elf', asset: 'race-elf-base', note: 'Hört, was der Wald noch weiß' },
+  { id: 'zwerg', label: 'Zwerg', asset: 'race-dwarf-base', note: 'Vertraut dem Stein mehr als der Karte' },
+  { id: 'goblin', label: 'Goblin', asset: 'race-goblin-base', note: 'Nimmt mit, was liegen bleibt' },
+  { id: 'ork', label: 'Ork', asset: 'race-orc-base', note: 'Geht weiter, wenn andere umkehren' },
+] as const
+
+type Ancestry = (typeof ancestries)[number]['id']
+
+export type CharacterDraft = {
+  name: string
+  ancestry: Ancestry
+  bodyVariant: string
+  skinVariant: string
+  hairStyle: string
+  hairColor: string
+}
+
+const defaults: CharacterDraft = {
+  name: '',
+  ancestry: 'mensch',
+  bodyVariant: 'ausgewogen',
+  skinVariant: 'warm',
+  hairStyle: 'kurz',
+  hairColor: 'dunkel',
+}
+
+const bodyOptions = [
+  ['schmal', 'Schmal'],
+  ['ausgewogen', 'Ausgewogen'],
+  ['kraeftig', 'Kräftig'],
+]
+const skinOptions = [
+  ['warm', 'Warm'],
+  ['kuehl', 'Kühl'],
+  ['moos', 'Moos'],
+  ['stein', 'Stein'],
+]
+const hairStyleOptions = [
+  ['kurz', 'Kurz'],
+  ['lang', 'Lang'],
+  ['geflochten', 'Geflochten'],
+]
+const hairColorOptions = [
+  ['dunkel', 'Dunkel'],
+  ['kastanie', 'Kastanie'],
+  ['kupfer', 'Kupfer'],
+  ['silber', 'Silber'],
+]
+
+export function CharacterCreator({ userId, initialCharacter }: { userId: string; initialCharacter: CharacterDraft | null }) {
+  const router = useRouter()
+  const [draft, setDraft] = useState<CharacterDraft>(initialCharacter ?? defaults)
+  const [status, setStatus] = useState<'idle' | 'saving' | 'error'>('idle')
+  const selectedAncestry = useMemo(
+    () => ancestries.find((ancestry) => ancestry.id === draft.ancestry) ?? ancestries[0],
+    [draft.ancestry],
+  )
+
+  function update<K extends keyof CharacterDraft>(key: K, value: CharacterDraft[K]) {
+    setDraft((current) => ({ ...current, [key]: value }))
+    if (status === 'error') setStatus('idle')
+  }
+
+  async function save(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const name = draft.name.trim()
+    if (!name) return
+
+    setStatus('saving')
+    const supabase = createSupabaseBrowserClient()
+    const { error } = await supabase.from('characters').upsert(
+      {
+        profile_id: userId,
+        name,
+        ancestry: draft.ancestry,
+        body_variant: draft.bodyVariant,
+        skin_variant: draft.skinVariant,
+        hair_style: draft.hairStyle,
+        hair_color: draft.hairColor,
+      },
+      { onConflict: 'profile_id' },
+    )
+
+    if (error) {
+      setStatus('error')
+      return
+    }
+
+    router.push('/camp')
+  }
+
+  return (
+    <form className={styles.creator} onSubmit={save}>
+      <fieldset className={styles.raceFieldset}>
+        <legend>Volk wählen</legend>
+        <div className={styles.raceGrid}>
+          {ancestries.map((ancestry) => {
+            const selected = draft.ancestry === ancestry.id
+            return (
+              <button
+                key={ancestry.id}
+                type="button"
+                className={styles.raceOption}
+                data-selected={selected}
+                aria-pressed={selected}
+                onClick={() => update('ancestry', ancestry.id)}
+              >
+                <svg viewBox="0 0 220 260" aria-hidden="true" focusable="false">
+                  <use href={`/assets/phase1-art-pack.svg#${ancestry.asset}`} />
+                </svg>
+                <strong>{ancestry.label}</strong>
+                <span>{ancestry.note}</span>
+              </button>
+            )
+          })}
+        </div>
+      </fieldset>
+
+      <section className={styles.detailPanel} aria-labelledby="appearance-title">
+        <div className={styles.preview} aria-hidden="true">
+          <svg viewBox="0 0 220 260" focusable="false">
+            <use href={`/assets/phase1-art-pack.svg#${selectedAncestry.asset}`} />
+          </svg>
+          <span>{draft.name.trim() || selectedAncestry.label}</span>
+        </div>
+
+        <div className={styles.controls}>
+          <h2 id="appearance-title">Dein Weggefährte</h2>
+          <label>
+            Name
+            <input
+              value={draft.name}
+              onChange={(event) => update('name', event.target.value)}
+              maxLength={80}
+              autoComplete="off"
+              required
+            />
+          </label>
+
+          <div className={styles.selectGrid}>
+            <Select label="Körperform" value={draft.bodyVariant} options={bodyOptions} onChange={(value) => update('bodyVariant', value)} />
+            <Select label="Haut / Fantasyfarbe" value={draft.skinVariant} options={skinOptions} onChange={(value) => update('skinVariant', value)} />
+            <Select label="Frisur" value={draft.hairStyle} options={hairStyleOptions} onChange={(value) => update('hairStyle', value)} />
+            <Select label="Haarfarbe" value={draft.hairColor} options={hairColorOptions} onChange={(value) => update('hairColor', value)} />
+          </div>
+
+          <p className={styles.scopeNote}>
+            Keine Werte, Klassen oder Boni: Diese Auswahl verändert nur, wer in deiner Geschichte sichtbar mitreist.
+          </p>
+
+          <div className={styles.actions}>
+            <p role="status" aria-live="polite">
+              {status === 'error' ? 'Der Charakter konnte nicht gespeichert werden. Versuch es bitte noch einmal.' : ''}
+            </p>
+            <button type="submit" disabled={status === 'saving'}>
+              {status === 'saving' ? 'Wird gespeichert …' : 'Ins Lager aufbrechen'}
+            </button>
+          </div>
+        </div>
+      </section>
+    </form>
+  )
+}
+
+function Select({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string
+  value: string
+  options: string[][]
+  onChange: (value: string) => void
+}) {
+  return (
+    <label>
+      {label}
+      <select value={value} onChange={(event) => onChange(event.target.value)}>
+        {options.map(([optionValue, optionLabel]) => (
+          <option key={optionValue} value={optionValue}>
+            {optionLabel}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}

--- a/app/character/character-creator.tsx
+++ b/app/character/character-creator.tsx
@@ -56,6 +56,26 @@ const hairColorOptions = [
   ['silber', 'Silber'],
 ]
 
+const skinColors: Record<string, string> = {
+  warm: '#c8a483',
+  kuehl: '#b5a6a2',
+  moos: '#879876',
+  stein: '#9a9288',
+}
+
+const hairColors: Record<string, string> = {
+  dunkel: '#49392f',
+  kastanie: '#704b36',
+  kupfer: '#9b5d35',
+  silber: '#b6b0a4',
+}
+
+const bodyScales: Record<string, number> = {
+  schmal: 0.88,
+  ausgewogen: 1,
+  kraeftig: 1.12,
+}
+
 export function CharacterCreator({ userId, initialCharacter }: { userId: string; initialCharacter: CharacterDraft | null }) {
   const router = useRouter()
   const [draft, setDraft] = useState<CharacterDraft>(initialCharacter ?? defaults)
@@ -127,9 +147,7 @@ export function CharacterCreator({ userId, initialCharacter }: { userId: string;
 
       <section className={styles.detailPanel} aria-labelledby="appearance-title">
         <div className={styles.preview} aria-hidden="true">
-          <svg viewBox="0 0 220 260" focusable="false">
-            <use href={`/assets/phase1-art-pack.svg#${selectedAncestry.asset}`} />
-          </svg>
+          <CharacterPreview draft={draft} asset={selectedAncestry.asset} />
           <span>{draft.name.trim() || selectedAncestry.label}</span>
         </div>
 
@@ -168,6 +186,62 @@ export function CharacterCreator({ userId, initialCharacter }: { userId: string;
         </div>
       </section>
     </form>
+  )
+}
+
+function CharacterPreview({ draft, asset }: { draft: CharacterDraft; asset: string }) {
+  const bodyScale = bodyScales[draft.bodyVariant] ?? 1
+  const skinColor = skinColors[draft.skinVariant] ?? skinColors.warm
+  const hairColor = hairColors[draft.hairColor] ?? hairColors.dunkel
+
+  return (
+    <svg className={styles.characterPreview} viewBox="0 0 512 512" focusable="false">
+      <g transform={`translate(256 0) scale(${bodyScale} 1) translate(-256 0)`}>
+        <use href={`/assets/phase1-art-pack.svg#${asset}`} />
+      </g>
+      <circle className={styles.skinLayer} cx="256" cy="150" r={draft.ancestry === 'goblin' ? 60 : 69} fill={skinColor} />
+      {draft.ancestry === 'elf' ? (
+        <path className={styles.skinLayer} d="M185 125L115 150L180 175ZM327 125L397 150L332 175Z" fill={skinColor} />
+      ) : null}
+      {draft.ancestry === 'goblin' ? (
+        <path className={styles.skinLayer} d="M185 120L95 110L178 175ZM327 120L417 110L334 175Z" fill={skinColor} />
+      ) : null}
+      {draft.ancestry === 'ork' ? (
+        <path className={styles.skinLayer} d="M185 135L130 155L182 178ZM327 135L382 155L330 178Z" fill={skinColor} />
+      ) : null}
+      <Hair style={draft.hairStyle} color={hairColor} ancestry={draft.ancestry} />
+    </svg>
+  )
+}
+
+function Hair({ style, color, ancestry }: { style: string; color: string; ancestry: Ancestry }) {
+  if (style === 'lang') {
+    return (
+      <path
+        className={styles.hairLayer}
+        d="M188 132Q205 66 256 64Q310 66 325 132L320 230Q298 197 286 174Q256 192 226 174Q214 199 193 230Z"
+        fill={color}
+      />
+    )
+  }
+
+  if (style === 'geflochten') {
+    return (
+      <g className={styles.hairLayer} fill={color}>
+        <path d="M188 132Q205 66 256 64Q310 66 325 132Q290 106 256 107Q222 106 188 132Z" />
+        <circle cx="306" cy="178" r="13" />
+        <circle cx="310" cy="202" r="11" />
+        <circle cx="307" cy="223" r="9" />
+      </g>
+    )
+  }
+
+  return (
+    <path
+      className={styles.hairLayer}
+      d={ancestry === 'goblin' ? 'M201 129Q225 80 256 82Q288 81 311 129Q281 111 256 112Q231 111 201 129Z' : 'M188 130Q207 69 256 67Q307 69 324 130Q289 104 256 105Q223 104 188 130Z'}
+      fill={color}
+    />
   )
 }
 

--- a/app/character/character.module.css
+++ b/app/character/character.module.css
@@ -1,0 +1,232 @@
+.shell {
+  width: min(100% - 32px, 1180px);
+  margin-inline: auto;
+  padding-block: clamp(32px, 6vw, 72px);
+  display: grid;
+  gap: 32px;
+}
+
+.heading {
+  display: grid;
+  gap: 10px;
+  max-width: 760px;
+}
+
+.heading h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 5vw, 4.2rem);
+  line-height: 1;
+}
+
+.heading p {
+  margin: 0;
+}
+
+.creator {
+  display: grid;
+  gap: 28px;
+}
+
+.raceFieldset {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.raceFieldset legend {
+  margin-bottom: 14px;
+  font-family: var(--font-display), serif;
+  font-weight: 700;
+}
+
+.raceGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.raceOption {
+  min-width: 0;
+  min-height: 220px;
+  padding: 18px 14px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface);
+  color: var(--text);
+  display: grid;
+  justify-items: center;
+  align-content: start;
+  gap: 10px;
+  text-align: center;
+}
+
+.raceOption:hover {
+  transform: translateY(-1px);
+}
+
+.raceOption[data-selected='true'] {
+  border-color: var(--accent);
+  background: var(--surface-raised);
+}
+
+.raceOption svg {
+  width: 100%;
+  height: 120px;
+}
+
+.raceOption strong {
+  font-family: var(--font-display), serif;
+  font-size: 1.05rem;
+}
+
+.raceOption span {
+  color: var(--text-muted);
+  font-size: .86rem;
+  line-height: 1.35;
+}
+
+.detailPanel {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  gap: clamp(24px, 5vw, 48px);
+  padding: clamp(22px, 4vw, 36px);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface);
+}
+
+.preview {
+  min-width: 0;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  background: var(--surface-raised);
+}
+
+.preview svg {
+  width: min(100%, 240px);
+}
+
+.preview span {
+  max-width: 100%;
+  color: var(--text);
+  font-family: var(--font-display), serif;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+  text-align: center;
+}
+
+.controls {
+  min-width: 0;
+  display: grid;
+  gap: 18px;
+}
+
+.controls h2 {
+  margin: 0;
+}
+
+.controls label {
+  display: grid;
+  gap: 7px;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.controls input,
+.controls select {
+  min-height: 48px;
+  width: 100%;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  color: var(--text);
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.selectGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.scopeNote {
+  margin: 0;
+  font-size: .94rem;
+}
+
+.actions {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.actions p {
+  margin: 0;
+  min-height: 1.4em;
+  color: var(--danger);
+}
+
+.actions button {
+  min-height: 48px;
+}
+
+.actions button:disabled {
+  cursor: progress;
+  opacity: .65;
+}
+
+@media (max-width: 900px) {
+  .raceGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .raceOption:last-child {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 700px) {
+  .detailPanel {
+    grid-template-columns: 1fr;
+  }
+
+  .preview {
+    min-height: 240px;
+  }
+
+  .selectGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .raceGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .raceOption:last-child {
+    grid-column: auto;
+  }
+
+  .raceOption {
+    min-height: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .raceOption {
+    transition: opacity 120ms ease-out;
+  }
+
+  .raceOption:hover {
+    transform: none;
+  }
+}

--- a/app/character/character.module.css
+++ b/app/character/character.module.css
@@ -105,10 +105,25 @@
   border: 1px solid var(--border-strong);
   border-radius: 14px;
   background: var(--surface-raised);
+  overflow: hidden;
 }
 
-.preview svg {
-  width: min(100%, 240px);
+.characterPreview {
+  width: min(100%, 260px);
+  max-height: 330px;
+}
+
+.skinLayer,
+.hairLayer {
+  pointer-events: none;
+}
+
+.skinLayer {
+  opacity: .96;
+}
+
+.hairLayer {
+  filter: drop-shadow(0 2px 0 rgb(20 17 13 / .24));
 }
 
 .preview span {

--- a/app/character/page.tsx
+++ b/app/character/page.tsx
@@ -3,6 +3,8 @@ import { createSupabaseServerClient } from '../../lib/supabase/server'
 import { CharacterCreator, type CharacterDraft } from './character-creator'
 import styles from './character.module.css'
 
+export const dynamic = 'force-dynamic'
+
 export default async function CharacterPage() {
   const supabase = await createSupabaseServerClient()
   const {

--- a/app/character/page.tsx
+++ b/app/character/page.tsx
@@ -1,0 +1,46 @@
+import { redirect } from 'next/navigation'
+import { createSupabaseServerClient } from '../../lib/supabase/server'
+import { CharacterCreator, type CharacterDraft } from './character-creator'
+import styles from './character.module.css'
+
+export default async function CharacterPage() {
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/account')
+  }
+
+  const { data: character } = await supabase
+    .from('characters')
+    .select('name, ancestry, body_variant, skin_variant, hair_style, hair_color')
+    .eq('profile_id', user.id)
+    .maybeSingle()
+
+  const initialCharacter: CharacterDraft | null = character
+    ? {
+        name: character.name,
+        ancestry: character.ancestry as CharacterDraft['ancestry'],
+        bodyVariant: character.body_variant,
+        skinVariant: character.skin_variant,
+        hairStyle: character.hair_style,
+        hairColor: character.hair_color,
+      }
+    : null
+
+  return (
+    <main id="main-content" className={styles.shell}>
+      <div className={styles.heading}>
+        <p className="eyebrow">Am Feuer · Schritt 2 von 2</p>
+        <h1>Wer bricht auf?</h1>
+        <p>
+          Dein Charakter bleibt bei dir. Volk und Aussehen erzählen, wer mit dir unterwegs ist — sie verändern weder
+          Fokusdauer noch Belohnungen.
+        </p>
+      </div>
+      <CharacterCreator userId={user.id} initialCharacter={initialCharacter} />
+    </main>
+  )
+}


### PR DESCRIPTION
Umsetzung von #11 auf Basis von Concept V2, dem bestehenden Charakter-Draft und dem Phase-1-Persistenzvertrag.

Enthalten:
- fünf Völker: Mensch, Elf, Zwerg, Goblin, Ork
- visuelle Auswahl mit den gelieferten Race-Assets aus `phase1-art-pack.svg`
- minimale, frei kombinierbare Varianten für Körperform, Haut-/Fantasyfarbe, Frisur und Haarfarbe
- Name mit 80-Zeichen-Grenze und sauberem Umbruch
- vollständige Tastaturbedienbarkeit über native Buttons, Selects und Input
- persistentes Upsert in `public.characters` unter bestehender owner-only RLS
- bestehende Charakterdaten werden beim erneuten Öffnen geladen
- nicht authentifizierte Nutzer werden nach `/account` zurückgeführt
- Abschluss führt zu `/camp` als Anschluss an #29
- responsive Darstellung ab 360 px und Reduced-Motion-Berücksichtigung

Nicht enthalten:
- keine Klassen, Stats, Boni oder Timerprofile
- keine Geschlechtsauswahl
- keine Tattoos, Narben, Patches, Make-up-Systeme oder Detailslider
- keine Änderungen am Persistenzschema oder an Senior-Developer-Dateien

Closes #11