### PR TITLE
ci: internes Phase-1-Preview einrichten

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,69 @@
+name: Internal Preview
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy-preview:
+    name: Deploy current main to internal preview
+    runs-on: ubuntu-latest
+    environment: preview
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify repository quality gates
+        run: |
+          npm run lint
+          npm run typecheck
+          npm test
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull preview project settings
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build preview
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy preview
+        id: deploy
+        shell: bash
+        run: |
+          set -euo pipefail
+          preview_url="$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})"
+          echo "url=${preview_url}" >> "$GITHUB_OUTPUT"
+          echo "### Internal Phase-1 Preview" >> "$GITHUB_STEP_SUMMARY"
+          echo "${preview_url}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify preview responds
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          node - <<'NODE'
+          const url = process.env.PREVIEW_URL
+          if (!url) throw new Error('Preview URL missing')
+          const response = await fetch(url, { redirect: 'follow' })
+          if (!response.ok) throw new Error(`Preview responded with ${response.status}`)
+          console.log(`Preview reachable: ${response.url}`)
+          NODE

--- a/docs/PREVIEW-DEPLOYMENT.md
+++ b/docs/PREVIEW-DEPLOYMENT.md
@@ -1,0 +1,41 @@
+# Internes Phase-1-Preview
+
+Dieses Preview ist ein interner Teststand für den jeweils aktuellen `main` und ausdrücklich **kein** öffentlicher Produktionsrelease.
+
+## Ziel
+
+Der Workflow `.github/workflows/preview.yml` deployt jeden Push auf `main` sowie manuelle Läufe als Vercel-Preview. Der erzeugte Link wird im GitHub-Actions-Run unter **Summary** ausgegeben und anschließend per HTTP-Smoke-Test geprüft.
+
+## Einmalige Einrichtung
+
+1. Das Repository als eigenes Vercel-Projekt importieren bzw. mit einem bestehenden Vercel-Projekt verknüpfen.
+2. In Vercel für die Umgebung **Preview** folgende Supabase-Werte hinterlegen:
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+3. In der Supabase-Preview-/Testinstanz unter **Authentication → URL Configuration** die Vercel-Preview-URL(s) als erlaubte Redirect-Ziele eintragen, damit Magic-Link-Login und Callback funktionieren.
+4. In GitHub die Environment **preview** verwenden und dort folgende Secrets hinterlegen:
+   - `VERCEL_TOKEN`
+   - `VERCEL_ORG_ID`
+   - `VERCEL_PROJECT_ID`
+5. Keine Supabase-Service-Role-Keys oder sonstigen produktiven Secrets in Git oder als `NEXT_PUBLIC_*`-Variable speichern.
+
+## Laufender Betrieb
+
+Nach jedem Merge in `main` startet der Preview-Workflow automatisch. Dadurch wächst der interne Browser-Teststand mit #29, #37, #38/#12/#21, #13 und #39 mit, ohne einen öffentlichen Release auszulösen.
+
+Ein manueller Lauf ist über **Actions → Internal Preview → Run workflow** möglich.
+
+## Abnahme
+
+Ein Lauf ist erfolgreich, wenn:
+- Lint, Typecheck und Tests grün sind,
+- Vercel das Projekt für die Preview-Umgebung baut,
+- ein Deployment-Link ausgegeben wird,
+- der HTTP-Smoke-Test auf diesen Link erfolgreich antwortet,
+- Account- und Charakterfluss mit der Preview-Supabase-Konfiguration im Browser getestet werden können.
+
+## Sicherheitsgrenzen
+
+- `.vercel` und lokale `.env`-Dateien bleiben über `.gitignore` aus dem Repository ausgeschlossen.
+- Preview und spätere Produktion verwenden getrennte Environment-Konfigurationen.
+- Dieses Setup ersetzt weder #3 noch spätere Release-, Domain-, Datenschutz- oder Monitoring-Gates.


### PR DESCRIPTION
Umsetzung von #51.

Enthalten:
- dedizierter GitHub-Actions-Workflow `Internal Preview` für jeden Push auf `main` und manuelle Läufe
- Vercel-Preview-Build/Deployment mit Token, Org- und Project-ID ausschließlich aus GitHub-Secrets
- bestehende Quality Gates vor dem Deployment
- Preview-URL im Actions-Summary
- HTTP-Smoke-Test gegen das erzeugte Deployment
- Dokumentation der getrennten Preview-Konfiguration für Vercel + Supabase/Auth-Redirects
- keine produktiven Secrets im Repository

Wichtig: Die einmaligen externen Vercel-/Supabase-Werte müssen in den jeweiligen Plattformen als Preview-Konfiguration vorhanden sein. Das Repository enthält bewusst keine Secrets.

Closes #51