### PR TITLE
#SENDEV Hostinger/focus Architektur-Follow-up (#54)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,8 @@ SUPABASE_SERVICE_ROLE_KEY=
 # DISCORD_CLIENT_ID=
 # DISCORD_CLIENT_SECRET=
 
+# Lokal bleibt localhost der Default.
+# Produktion: NEXT_PUBLIC_SITE_URL=https://focus.lang-jamin.de
+# Der Produktionswert wird ausschließlich in der freigegebenen Deployment-Umgebung gesetzt
+# und erst mit dem kontrollierten Cutover aus Issue #3 aktiviert.
 NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Eine Cozy-Fantasy-Fokus-App: Arbeit wird zur Quest, echte Fokuszeit bewegt den Charakter durch eine illustrierte Welt und lässt das persönliche Lager wachsen.
 
-**Ziel-Domain:** `pomodoro.lang-jamin.de`  
+**Ziel-Domain:** `focus.lang-jamin.de`  
 **Status:** Concept V2 ist die verbindliche Produktspezifikation; Umsetzung startet mit einem Vertical Slice.  
 **Owner:** @yamahabenny-gif
 

--- a/design/README.md
+++ b/design/README.md
@@ -11,7 +11,7 @@ erzeugt.
 
 | Artboard | Screen |
 |---|---|
-| `Landing.dc.html` | Landing für `pomodoro.lang-jamin.de` |
+| `Landing.dc.html` | Landing für `focus.lang-jamin.de` |
 | `Login.dc.html` | Login — „Die Tavernentür" |
 | `Klassen.dc.html` | Klassenwahl |
 | `Main.dc.html` | Quest-Screen (Haupt-Timer) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,12 +6,12 @@
 
 | Ebene | Wahl | Begründung |
 |---|---|---|
-| Framework | **Next.js 15** (App Router, TypeScript) | Das Hosting-Team deployt auf Vercel; Next ist dort der Pfad des geringsten Widerstands. |
+| Framework | **Next.js 15** (App Router, TypeScript) | App Router, Route Handlers und serverseitige Ausführung passen zu Auth-, Zeit- und Reward-Pfaden. Das Framework bleibt unabhängig vom konkreten Hostinganbieter. |
 | Styling | **Tailwind CSS v4** + **shadcn/ui** | shadcn kopiert Komponenten ins Repo statt sie zu verstecken — bei einem so eigenwilligen Look wichtig, weil wir viel überschreiben. |
 | Auth | **Supabase Auth** — Magic Link, Discord OAuth | Discord, weil die Zielgruppe dort ist. **Kein Gastzugang** — Konto und Charakter sind Pflicht, weil Fortschritt, Inventar und Level geräteübergreifend erhalten bleiben müssen (Entscheidung zu W5, Issue #30). |
 | Datenbank | **Supabase Postgres** + Row Level Security | RLS macht die Zugriffsregeln zu Datenbank-Constraints statt zu Anwendungslogik. |
 | Realtime | **Supabase Realtime** (Broadcast + Presence) | Siehe [SYNC-PROTOCOL.md](SYNC-PROTOCOL.md). |
-| Hosting | **Vercel** → `pomodoro.lang-jamin.de` | Übergabe an das Hosting-Team, siehe unten. |
+| Hosting | **Hostinger** → `focus.lang-jamin.de` | Zielarchitektur gemäß ADR-036 / Issue #3. Konkreter Hostinger-Laufzeitmodus muss vor Produktions-Cutover qualifiziert werden. |
 | Tests | **Vitest** (Logik) + **Playwright** (E2E, mehrere Kontexte) | Der Sync ist nur mit zwei echten Browser-Kontexten sinnvoll testbar. |
 
 **Warum kein eigener WebSocket-Server?** Weil das Protokoll fast zustandslos ist. Wir
@@ -116,19 +116,37 @@ Das ist ein Fokus-Tool, kein Zeiterfassungssystem. Konkret:
 
 - Wir speichern Fokus-**Dauern**, keine Inhalte. Es gibt kein Feld für "woran arbeitest du".
 - Innerhalb der Party sehen andere: Anzeigename, Klasse, ob gerade aktiv. Sonst nichts.
-- Kein Analytics-Tool mit Personenbezug. Falls Metriken gebraucht werden: Vercel
-  Analytics ohne Cookies.
+- Kein personenbezogenes Analytics ohne separate Datenschutz- und Architekturentscheidung.
+  Hosting-Provider-Metriken oder externe Analytics dürfen nicht stillschweigend aktiviert werden.
 - Export und Löschung des eigenen Accounts sind Teil von M5, nicht "später".
 
 ## Übergabe an das Hosting-Team
 
-Damit `pomodoro.lang-jamin.de` live gehen kann, braucht das Team:
+Öffentliches Produktionsziel ist `https://focus.lang-jamin.de`. Die Hostinger-Subdomain-
+Infrastruktur ist bereits vorbereitet; das ist **noch kein App-Deployment**. Der kontrollierte
+Produktions-Cutover bleibt in **Issue #3** gegatet.
 
-1. **Vercel-Projekt** verbunden mit diesem Repo. Production-Branch: `main`.
-2. **DNS**: `CNAME pomodoro → cname.vercel-dns.com` in der Zone `lang-jamin.de`.
-3. **Supabase-Projekt** (Region `eu-central-1`, wegen DSGVO und Latenz).
-4. **Environment-Variablen** — die vollständige Liste steht in `.env.example`.
-5. **Migrationen**: `supabase db push` gegen das Produktions-Projekt.
+Vor dem Cutover müssen mindestens folgende Punkte nachgewiesen und dokumentiert sein:
 
-Die genaue Checkliste inklusive Reihenfolge liegt als Issue
-`#release #SENDEV Deployment-Setup pomodoro.lang-jamin.de`.
+1. **Vertical Slice #35** intern vollständig abgenommen.
+2. **Hostinger-Laufzeit qualifiziert:** konkreter Tarif/Betriebsmodus, unterstützte Node.js-Version,
+   `npm run build`/`npm run start`, Route Handlers, persistenter Prozess, Logs/Monitoring und Rollback.
+3. **Pre-Cutover-Backup/Snapshot** des aktuellen `focus`-Zustands erstellt und Wiederherstellung geprüft.
+4. **Freigegebener Produktions-Build** aus einem dokumentierten Commit erzeugt.
+5. **Secrets ausschließlich serverseitig:** `SUPABASE_SERVICE_ROLE_KEY` niemals als `NEXT_PUBLIC_*`,
+   im Client-Bundle, Build-Artefakt oder Log veröffentlichen.
+6. **Supabase Auth** auf `https://focus.lang-jamin.de` vorbereitet: Site URL und Redirect-Allowlist
+   sowie Magic-Link-/OAuth-Flows end-to-end testen.
+7. **HTTPS, Deep Links/Reload, serverseitige Endpunkte, kritische Assets und Supabase Realtime** testen.
+8. **DNS-Zielwerte/TTL und Cutover-Fenster** erst aus dem tatsächlich qualifizierten Hostinger-Ziel ableiten;
+   keine früheren Vercel-CNAME-Werte übernehmen.
+9. **Technical Owner + Release-Team-Freigabe** in Issue #3 dokumentieren.
+
+Bis diese Laufzeitqualifikation vorliegt, werden `next.config.mjs`, `package.json` und Deployment-CI
+nicht vorsorglich auf Hostinger-spezifische Annahmen umgebaut. Falls der verfügbare Hostinger-Betrieb
+keine benötigte Next.js-Serverlaufzeit unterstützt, ist vor Implementierung eine separate
+Architekturentscheidung nötig; ein statischer Export wird nicht implizit angenommen.
+
+Supabase bleibt unabhängig vom Webhosting für Auth, Postgres und Realtime vorgesehen. Ein Hostingwechsel
+erfordert nicht automatisch eine Schemaänderung; produktive Migrationen bleiben separat reproduzierbar,
+RLS-geprüft und release-gegatet.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -61,6 +61,13 @@ Ungefähr zehn sichtbare Quests; abgeschlossene werden nachgefüllt. Keine Frist
 **Status:** angenommen  
 Drei persistente Akte mit Rasten; Boss/Höhepunkt in Akt III. Kein 90-Minuten-Dauerblock.
 
+### ADR-036 · Produktionsziel Hostinger / `focus.lang-jamin.de`
+**Status:** angenommen · 2026-09-04  
+**Kontext:** Die Hostinger-Subdomain-Infrastruktur wurde bereits auf `focus.lang-jamin.de` umgewidmet; die bisherige Repo-Dokumentation nannte weiterhin Vercel und `pomodoro.lang-jamin.de`.  
+**Entscheidung:** Öffentliche Ziel-URL ist `https://focus.lang-jamin.de`; Hostinger ist das vorgesehene Produktionshosting, Supabase bleibt für Auth/Postgres/Realtime. Anbieterabhängige Next.js-Konfiguration und der eigentliche Cutover folgen erst nach nachgewiesener Hostinger-Laufzeitqualifikation und den Gates aus Issue #3.  
+**Alternative:** Vercel und die bisherige Domain unverändert als Produktionsziel beibehalten.  
+**Grund:** Die vorhandene Infrastruktur und Ziel-Domain sollen konsistent dokumentiert werden, ohne unbestätigte Hostinger-Runtime-Eigenschaften oder einen vorzeitigen Produktions-Cutover anzunehmen.
+
 ---
 
 ## Concept-V2-Entscheidungen

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -52,7 +52,7 @@ hat, ist noch kein `#junDev`-Issue.
 Alles, was nach außen wirkt oder schwer rückholbar ist. **Merge erst nach ausdrücklicher
 Freigabe durch das Release Team.**
 
-- Deployment auf `pomodoro.lang-jamin.de`
+- Deployment auf `focus.lang-jamin.de`
 - DNS- und Domain-Änderungen
 - Schema-Migrationen gegen Produktion
 - Änderungen an öffentlichen Texten, Impressum, Datenschutzerklärung
@@ -61,6 +61,10 @@ Freigabe durch das Release Team.**
 
 `#release` ersetzt `#SENDEV`/`#junDev` nicht — es kommt dazu. Ein Deployment ist
 `#release #SENDEV`.
+
+Der kanonische öffentliche Release-Tracker ist **Issue #3**. Die in #3 dokumentierten
+Hostinger-Laufzeit-, Backup-, Auth-, DNS- und Rollback-Gates müssen vor jedem Produktions-
+Cutover erfüllt sein. Ein gemergter Architektur- oder Dokumentations-PR ist kein Deployment.
 
 ## Issues
 
@@ -71,7 +75,7 @@ Titelformat:
 ```
 #SENDEV Party-Sync: Clock-Skew-Abgleich implementieren
 #junDev Chest-Opening-Animation mit Reduced-Motion-Fallback
-#release #SENDEV Deployment-Setup pomodoro.lang-jamin.de
+#release #SENDEV Hostinger-Deployment für focus.lang-jamin.de
 ```
 
 Fällt dir bei der Arbeit etwas Zusätzliches auf, gilt: **nicht nebenbei miterledigen,


### PR DESCRIPTION
## Ziel
Überführt den in PR #53 gemergten Hostinger-/`focus.lang-jamin.de`-Handoff in die kanonischen Repo-Dokumente.

## Änderungen
- ADR-036 für Hostinger / `focus.lang-jamin.de`
- Hostingziel und Release-Handoff in `docs/ARCHITECTURE.md` aktualisiert
- Ziel-Domain in README und Design-Doku angepasst
- Release-Workflow auf Issue #3 und neue Domain ausgerichtet
- `.env.example` dokumentiert den Produktionswert, ohne ihn lokal zu aktivieren

## Bewusst nicht enthalten
- kein App-/DNS-/Supabase-Cutover
- keine Hostinger-spezifischen Runtime-Annahmen in `next.config.mjs` oder `package.json`
- keine Secrets

## Review-Fokus
Bitte insbesondere prüfen, dass die Dokumentation Hostinger als Ziel festhält, aber die tatsächliche Produktionsumstellung weiterhin durch #3 und die dortigen Laufzeit-/Backup-/Security-Gates blockiert bleibt.

Closes #54
Refs #3, #53