### PR TITLE
#SENDEV Hostinger-Runtime-Qualifikation (#58)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@
 | Auth | **Supabase Auth** — Magic Link, Discord OAuth | Discord, weil die Zielgruppe dort ist. **Kein Gastzugang** — Konto und Charakter sind Pflicht, weil Fortschritt, Inventar und Level geräteübergreifend erhalten bleiben müssen (Entscheidung zu W5, Issue #30). |
 | Datenbank | **Supabase Postgres** + Row Level Security | RLS macht die Zugriffsregeln zu Datenbank-Constraints statt zu Anwendungslogik. |
 | Realtime | **Supabase Realtime** (Broadcast + Presence) | Siehe [SYNC-PROTOCOL.md](SYNC-PROTOCOL.md). |
-| Hosting | **Hostinger** → `focus.lang-jamin.de` | Zielarchitektur gemäß ADR-036 / Issue #3. Konkreter Hostinger-Laufzeitmodus muss vor Produktions-Cutover qualifiziert werden. |
+| Hosting | **Hostinger** → `focus.lang-jamin.de` | Zielarchitektur gemäß ADR-036 / Issue #3. Die Plattform-Kompatibilität ist in [HOSTINGER-RUNTIME-QUALIFICATION.md](HOSTINGER-RUNTIME-QUALIFICATION.md) belegt; der konkrete Account/Tarif bleibt vor Produktions-Cutover zu verifizieren. |
 | Tests | **Vitest** (Logik) + **Playwright** (E2E, mehrere Kontexte) | Der Sync ist nur mit zwei echten Browser-Kontexten sinnvoll testbar. |
 
 **Warum kein eigener WebSocket-Server?** Weil das Protokoll fast zustandslos ist. Wir
@@ -126,11 +126,17 @@ Das ist ein Fokus-Tool, kein Zeiterfassungssystem. Konkret:
 Infrastruktur ist bereits vorbereitet; das ist **noch kein App-Deployment**. Der kontrollierte
 Produktions-Cutover bleibt in **Issue #3** gegatet.
 
+Die dokumentierte Plattform-Kompatibilität liegt in
+[HOSTINGER-RUNTIME-QUALIFICATION.md](HOSTINGER-RUNTIME-QUALIFICATION.md). Sie bestätigt,
+dass Hostingers Managed-Node.js-Plattform die benötigte Next.js-Serverarchitektur grundsätzlich
+tragen kann. Sie ersetzt **nicht** die noch ausstehende hPanel-Verifikation des konkreten Tarifs
+und Zielbetriebs für `focus.lang-jamin.de`.
+
 Vor dem Cutover müssen mindestens folgende Punkte nachgewiesen und dokumentiert sein:
 
 1. **Vertical Slice #35** intern vollständig abgenommen.
-2. **Hostinger-Laufzeit qualifiziert:** konkreter Tarif/Betriebsmodus, unterstützte Node.js-Version,
-   `npm run build`/`npm run start`, Route Handlers, persistenter Prozess, Logs/Monitoring und Rollback.
+2. **Hostinger-Zielbetrieb account-spezifisch qualifiziert:** konkreter Tarif/Betriebsmodus,
+   tatsächlich auswählbare Node.js-Version, Build/Start-Einstellungen, Runtime-Logs und Rollback.
 3. **Pre-Cutover-Backup/Snapshot** des aktuellen `focus`-Zustands erstellt und Wiederherstellung geprüft.
 4. **Freigegebener Produktions-Build** aus einem dokumentierten Commit erzeugt.
 5. **Secrets ausschließlich serverseitig:** `SUPABASE_SERVICE_ROLE_KEY` niemals als `NEXT_PUBLIC_*`,
@@ -142,10 +148,10 @@ Vor dem Cutover müssen mindestens folgende Punkte nachgewiesen und dokumentiert
    keine früheren Vercel-CNAME-Werte übernehmen.
 9. **Technical Owner + Release-Team-Freigabe** in Issue #3 dokumentieren.
 
-Bis diese Laufzeitqualifikation vorliegt, werden `next.config.mjs`, `package.json` und Deployment-CI
-nicht vorsorglich auf Hostinger-spezifische Annahmen umgebaut. Falls der verfügbare Hostinger-Betrieb
-keine benötigte Next.js-Serverlaufzeit unterstützt, ist vor Implementierung eine separate
-Architekturentscheidung nötig; ein statischer Export wird nicht implizit angenommen.
+Bis die account-spezifische Laufzeitqualifikation vorliegt, werden `next.config.mjs`, `package.json`
+und Deployment-CI nicht vorsorglich auf Hostinger-spezifische Annahmen umgebaut. Falls der verfügbare
+Hostinger-Betrieb keine benötigte Next.js-Serverlaufzeit unterstützt, ist vor Implementierung eine
+separate Architekturentscheidung nötig; ein statischer Export wird nicht implizit angenommen.
 
 Supabase bleibt unabhängig vom Webhosting für Auth, Postgres und Realtime vorgesehen. Ein Hostingwechsel
 erfordert nicht automatisch eine Schemaänderung; produktive Migrationen bleiben separat reproduzierbar,

--- a/docs/HOSTINGER-RUNTIME-QUALIFICATION.md
+++ b/docs/HOSTINGER-RUNTIME-QUALIFICATION.md
@@ -1,0 +1,84 @@
+# Hostinger Runtime Qualification — `focus.lang-jamin.de`
+
+**Issue:** #58  
+**Release tracker:** #3  
+**Scope:** Technical qualification only. **No production cutover.**
+
+## Result
+
+The current application architecture is **compatible in principle** with Hostinger's managed Node.js web-app hosting, provided the concrete hosting account for `focus.lang-jamin.de` has a plan with Node.js Web App support enabled.
+
+This is not yet an account-specific production approval. The remaining hard gate is to verify in hPanel which concrete Hostinger plan/runtime is attached to the target and that `Node.js Web App` can be selected for this site.
+
+## Evidence
+
+### Next.js server capabilities
+
+Hostinger documents managed Next.js hosting with Node.js runtime support for SSR, ISR and API routes. Next.js itself documents that a normal Node.js server using `next build` + `next start` supports all framework features, including server-side features required by this repository.
+
+Sources:
+- https://www.hostinger.com/de/web-apps-hosting/nextjs-hosting
+- https://www.hostinger.com/support/how-to-deploy-a-nodejs-website-in-hostinger/
+- https://nextjs.org/docs/15/app/getting-started/deploying
+
+### Supported Node.js versions
+
+Hostinger currently documents selectable Node.js runtimes **18.x, 20.x, 22.x and 24.x** for managed Node.js applications.
+
+The repository currently uses Next.js `^15.5.2` and React 19. For this project, **Node.js 22.x is the preferred deployment target** during qualification because it is directly supported by Hostinger and aligns with the repository's current `@types/node` major. This document deliberately does not add an `engines` pin to `package.json` until the concrete hPanel runtime has been confirmed.
+
+Sources:
+- https://www.hostinger.com/support/how-to-select-the-node-js-version-for-your-application/
+- https://www.hostinger.com/support/how-to-deploy-a-nodejs-website-in-hostinger/
+
+### Build and start contract
+
+The repository already exposes:
+
+```json
+{
+  "scripts": {
+    "build": "next build",
+    "start": "next start"
+  }
+}
+```
+
+That is the standard Next.js Node.js deployment contract. No static export is required or desired.
+
+### Process lifecycle and logs
+
+Hostinger documents managed process handling for Node.js web apps and exposes runtime logs in hPanel. Its API also exposes a restart operation for server-side Node.js applications such as Next.js.
+
+Sources:
+- https://www.hostinger.com/tutorials/deploy-node-js-application
+- https://www.hostinger.com/support/how-to-use-node-js-runtime-logs-at-hostinger/
+- https://developers.hostinger.com/
+
+### Environment variables / secrets
+
+Hostinger's Node.js deployment flow supports environment variables in the deployment settings. This is compatible with the repository requirement that `SUPABASE_SERVICE_ROLE_KEY` remain server-side and never be stored in Git or exposed as `NEXT_PUBLIC_*`.
+
+Source:
+- https://www.hostinger.com/tutorials/deploy-node-js-application
+
+## Required hPanel verification before production work
+
+The following must be read back from the actual Hostinger account before any deployment-related repository change or cutover:
+
+1. `focus.lang-jamin.de` is attached to a plan that exposes **Node.js Web App** hosting. Hostinger currently documents this for Business Web Hosting and Cloud plans; VPS is also possible but is a different operational model.
+2. Framework detection offers **Next.js** for the repository.
+3. **Node.js 22.x** (or another explicitly approved compatible version) can be selected.
+4. Build command resolves to `npm run build` and server start resolves to `npm run start` / the managed equivalent.
+5. Runtime logs are visible after a test deployment.
+6. Environment variables can be configured without writing secrets into the repository.
+7. A previous deployment/commit can be redeployed or otherwise restored; the exact rollback interaction must be captured from the actual hPanel account.
+8. Domain attachment and HTTPS can be configured for `focus.lang-jamin.de` without changing DNS yet.
+
+## Decision boundary
+
+**Qualified now:** Hostinger's documented managed Node.js platform can support this Next.js architecture; the repository's current build/start model is compatible; no static-export redesign is indicated.
+
+**Not qualified yet:** the concrete Hostinger account/plan and its rollback behavior for `focus.lang-jamin.de` have not been read back from hPanel in this repository workflow.
+
+Until that account-specific verification is documented, Issue #3 remains blocked for production cutover. No DNS, Supabase production configuration, secrets, production build deployment or public release is authorized by this document.


### PR DESCRIPTION
## Ziel
Qualifiziert die Hostinger-Laufzeit für `focus.lang-jamin.de` technisch, ohne einen Produktions-Cutover auszulösen.

## Ergebnis
- Hostinger Managed Node.js unterstützt Next.js inkl. SSR/ISR/API-Routen.
- Hostinger dokumentiert Node.js 18/20/22/24; für die konkrete Verifikation ist 22.x vorgesehen.
- Repo besitzt bereits den standardmäßigen Next.js-Vertrag `npm run build` + `npm run start`.
- Runtime-Logs, Environment-Variablen und Restart/Managed-Process-Funktionen sind dokumentiert.
- Kein statischer Export notwendig.
- Die account-spezifische hPanel-/Tarif-Prüfung bleibt als letztes Runtime-Gate offen.

## Geändert
- neues `docs/HOSTINGER-RUNTIME-QUALIFICATION.md`
- `docs/ARCHITECTURE.md` verlinkt die Qualifikation und trennt Plattform-Kompatibilität vom konkreten Account-Gate

## Bewusst nicht enthalten
- kein DNS-Cutover
- kein Supabase-Produktions-Cutover
- keine Secrets
- kein App-Deployment
- keine Änderung an `next.config.mjs` oder `package.json`, solange der konkrete hPanel-Zielbetrieb nicht bestätigt ist

Closes #58
Refs #3, #53, #56