### PR TITLE
feat: Abenteuerbuch mit erster kuratierter Quest

### DIFF
--- a/app/adventure-book/adventure-book.module.css
+++ b/app/adventure-book/adventure-book.module.css
@@ -1,0 +1,152 @@
+.shell {
+  min-height: 100dvh;
+  padding: clamp(24px, 5vw, 72px);
+  background:
+    radial-gradient(circle at 50% 18%, rgb(212 167 44 / .08), transparent 32%),
+    #14110d;
+  color: var(--text);
+}
+
+.book {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+}
+
+.heading {
+  width: min(720px, 100%);
+  margin-bottom: clamp(28px, 5vw, 52px);
+}
+
+.heading h1 {
+  margin: 8px 0 14px;
+  font-size: clamp(2.25rem, 6vw, 4.8rem);
+  line-height: .98;
+}
+
+.heading p:last-child {
+  max-width: 58ch;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  line-height: 1.6;
+}
+
+.quest {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, .85fr);
+  min-height: 520px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.questArt {
+  min-height: 420px;
+  background: #101713;
+}
+
+.questArt svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.questCopy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(28px, 5vw, 58px);
+}
+
+.meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 18px;
+  color: var(--text-muted);
+  font-size: .95rem;
+}
+
+.meta strong {
+  color: var(--accent);
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  font-variant-numeric: tabular-nums;
+}
+
+.questCopy h2 {
+  margin: 0 0 18px;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1.02;
+}
+
+.questCopy p {
+  margin: 0 0 14px;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.departure {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  align-self: flex-start;
+  margin-top: 18px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--accent);
+  color: var(--text);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.departure span {
+  transition: transform 160ms ease-out;
+}
+
+.departure:hover span {
+  transform: translateX(4px);
+}
+
+.departure:focus-visible,
+.back:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 6px;
+}
+
+.back {
+  display: inline-block;
+  margin-top: 24px;
+  color: var(--text-muted);
+  text-decoration: none;
+}
+
+@media (max-width: 780px) {
+  .shell {
+    padding: 24px 18px 36px;
+  }
+
+  .quest {
+    grid-template-columns: 1fr;
+  }
+
+  .questArt {
+    min-height: 260px;
+  }
+
+  .meta {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .departure span {
+    transition: none;
+  }
+
+  .departure:hover span {
+    transform: none;
+  }
+}

--- a/app/adventure-book/page.tsx
+++ b/app/adventure-book/page.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { createSupabaseServerClient } from '../../lib/supabase/server'
+import styles from './adventure-book.module.css'
+
+export const dynamic = 'force-dynamic'
+
+export default async function AdventureBookPage() {
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) redirect('/account')
+
+  const { data: character } = await supabase
+    .from('characters')
+    .select('name')
+    .eq('profile_id', user.id)
+    .maybeSingle()
+
+  if (!character) redirect('/character')
+
+  return (
+    <main id="main-content" className={styles.shell}>
+      <section className={styles.book} aria-labelledby="book-title">
+        <div className={styles.heading}>
+          <p className="eyebrow">Abenteuerbuch</p>
+          <h1 id="book-title">Heute wartet nur ein Weg.</h1>
+          <p>
+            Kein Stapel voller Pflichten. Nur eine kleine Spur im Unterholz, die für fünfzehn ruhige Minuten deine
+            Aufmerksamkeit gebrauchen könnte.
+          </p>
+        </div>
+
+        <article className={styles.quest} aria-labelledby="quest-title">
+          <div className={styles.questArt} aria-hidden="true">
+            <svg viewBox="0 0 1600 900" focusable="false">
+              <use href="/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-01" />
+            </svg>
+          </div>
+
+          <div className={styles.questCopy}>
+            <div className={styles.meta}>
+              <span>Erste Quest</span>
+              <strong>15 Minuten</strong>
+            </div>
+            <h2 id="quest-title">Ein Licht im Unterholz</h2>
+            <p>
+              Zwischen Farnen flackert ein schwaches Licht. Folge ihm ein Stück und widme dich dabei genau einer Sache,
+              die heute wirklich weiterkommen soll.
+            </p>
+            <p>Du musst nichts beweisen. Fünfzehn Minuten reichen für diesen Abschnitt des Weges.</p>
+
+            <Link className={styles.departure} href="/quest/first-light">
+              Zum Aufbruch
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+        </article>
+
+        <Link className={styles.back} href="/camp">
+          Zurück ans Feuer
+        </Link>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
Umsetzung von #37 auf aktuellem `main`.

Enthalten:
- `/adventure-book` als diegetischer Einstieg aus dem Lager
- genau eine kuratierte Quest: `Ein Licht im Unterholz`
- Dauer prominent als 15 Minuten
- 1–2 kurze Auftragsabsätze ohne FOMO, Frist oder Countdown
- Integration des gelieferten `quest-light-undergrowth-beat-01`-Artworks
- semantischer, tastaturbedienbarer CTA zum späteren Aufbruchsritual unter `/quest/first-light`
- Rückweg ins Lager
- responsive Darstellung und Reduced-Motion-Rücksicht

Nicht enthalten:
- kein Questpool
- keine Filter 15/25/50/Episch
- keine Timer-/Session-Logik aus #38/#12
- keine neuen Persistenzfelder

Closes #37