### PR TITLE
#release #62 Static Placeholder für focus.lang-jamin.de

### DIFF
--- a/hosting/focus-placeholder/index.html
+++ b/hosting/focus-placeholder/index.html
@@ -7,9 +7,6 @@
 <meta name="description" content="Fokus wird zum Abenteuer. Eine Cozy-Fantasy-Fokus-App entsteht gerade — bald hier.">
 <meta name="theme-color" content="#14110D" media="(prefers-color-scheme: dark)">
 <meta name="theme-color" content="#F2EADB" media="(prefers-color-scheme: light)">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&family=Alegreya+Sans:wght@400;500;700&display=swap">
 <style>
   :root{
     --bg:#14110D; --bg-rgb:20,17,13; --text:#EDE4D3; --muted:#A8977B; --accent:#D4A72C; --border:#3A3126;
@@ -21,7 +18,7 @@
   html{background:var(--bg);color-scheme:dark light}
   body{
     margin:0; min-height:100dvh; position:relative; background:var(--bg); color:var(--text);
-    font-family:"Alegreya Sans",Georgia,serif;
+    font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
     display:flex; align-items:center; justify-content:center; padding:32px;
     -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
   }
@@ -39,7 +36,7 @@
     color:var(--accent);
   }
   h1{
-    margin:0; font-family:"Cinzel",Georgia,serif; font-weight:700; letter-spacing:.01em;
+    margin:0; font-family:Georgia,serif; font-weight:700; letter-spacing:.01em;
     font-size:clamp(28px,5vw,40px); line-height:1.2; text-wrap:balance;
   }
   p.lede{
@@ -70,11 +67,7 @@
 
     <p class="eyebrow">lang-jamin.de</p>
     <h1>Fokus wird zum Abenteuer.</h1>
-    <p class="lede">
-      Eine Cozy-Fantasy-Fokus-App entsteht: Arbeitszeit wird zur Quest, echte
-      Fokuszeit bewegt deinen Charakter durch eine illustrierte Welt und lässt
-      dein eigenes Lager wachsen.
-    </p>
+    <p class="lede">Eine Cozy-Fantasy-Fokus-App: Arbeit wird zur Quest, echte Fokuszeit bewegt den Charakter durch eine illustrierte Welt und lässt das persönliche Lager wachsen.</p>
 
     <div class="status" role="status"><i aria-hidden="true"></i>Im Bau — bald hier</div>
 


### PR DESCRIPTION
## Was ändert sich

Stellt den geprüftem, statischen Placeholder für `focus.lang-jamin.de` zur Review bereit.

- Entfernt externe Google-Fonts- und Preconnect-Abhängigkeiten.
- Übernimmt die freigegebene Kurzbeschreibung unverändert.
- Behält ausschließlich lokale/static Assets (`assets/backdrop.jpg`) bei.

## Release- und Sicherheitsgrenze

- Refs #62
- Unabhängige `#sen-dev`-, `#Tester`- und `#Security`-Gates: PASS.
- Kein Merge durch Mordecai; kein DNS-, Supabase- oder App-Cutover.
- Der Hostinger-Upload erfolgt erst nach Technical-Owner-Merge in einem separaten Release-Schritt mit öffentlichem Readback.

## Zuständigkeit

`#release` Publisher-Handoff; Technical Owner reviewt und merged.
