### PR TITLE
#junDev #SENDEV Vertical Slice: Aufbruch, Fokus, Rast, Truhe

### DIFF
--- a/app/quest/first-light/first-light.module.css
+++ b/app/quest/first-light/first-light.module.css
@@ -1,0 +1,263 @@
+.shell {
+  min-height: 100dvh;
+  background: #111713;
+  color: var(--text);
+  display: grid;
+  place-items: center;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.error {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  background: var(--danger);
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 8px;
+}
+
+.card {
+  position: relative;
+  width: min(100% - 32px, 640px);
+  padding: clamp(24px, 6vw, 56px);
+  border-radius: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 14px;
+  text-align: center;
+  justify-items: center;
+}
+
+.card h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+}
+
+.rewardList {
+  display: flex;
+  gap: clamp(16px, 4vw, 40px);
+  margin: 8px 0;
+}
+
+.rewardList div {
+  display: grid;
+  gap: 2px;
+}
+
+.rewardList dt {
+  color: var(--text-muted);
+  font-size: .8rem;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+}
+
+.rewardList dd {
+  margin: 0;
+  font-weight: 700;
+  color: var(--accent);
+  font-size: 1.1rem;
+}
+
+.chestArt,
+.resolutionArt {
+  width: min(100%, 420px);
+  aspect-ratio: 16 / 9;
+}
+
+/* Aufbruch */
+
+.departure {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: end center;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.departureArt {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  animation: fadeIn 4s ease-out both;
+}
+
+.departureCopy {
+  padding: clamp(24px, 6vw, 64px);
+  text-align: center;
+  text-shadow: 0 2px 16px rgb(0 0 0 / .72);
+}
+
+.departureCopy h1 {
+  max-width: 24ch;
+  margin: 8px auto 0;
+  font-size: clamp(1.4rem, 3.6vw, 2rem);
+  color: #f4ead8;
+}
+
+/* Fokus */
+
+.focusStage {
+  position: fixed;
+  inset: 0;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+.beatLayer {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+}
+
+.beat {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 1.6s ease-in-out;
+}
+
+.beat[data-active='true'] {
+  opacity: 1;
+}
+
+.silhouette {
+  position: absolute;
+  left: 50%;
+  bottom: 8%;
+  z-index: -1;
+  width: clamp(80px, 12vw, 140px);
+  transition: transform 1s linear;
+  filter: drop-shadow(0 10px 18px rgb(0 0 0 / .5));
+}
+
+.timerPanel {
+  position: absolute;
+  left: 50%;
+  bottom: clamp(24px, 6vh, 64px);
+  transform: translateX(-50%);
+  width: min(92%, 420px);
+  padding: clamp(16px, 3vw, 28px);
+  border-radius: 14px;
+  background: rgb(17 23 19 / .55);
+  backdrop-filter: blur(6px);
+  text-align: center;
+  color: #f4ead8;
+}
+
+.timer {
+  font-family: var(--font-display), serif;
+  font-size: clamp(2.4rem, 8vw, 3.6rem);
+  margin: 4px 0 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+
+.controls button {
+  background: transparent;
+  border: 1px solid rgb(212 167 44 / .5);
+  color: #f4ead8;
+  padding: 8px 14px;
+  font-size: .85rem;
+}
+
+.leave {
+  border-color: rgb(217 100 90 / .5) !important;
+  color: #f2b7b1 !important;
+}
+
+/* Rast */
+
+.restStage {
+  position: fixed;
+  inset: 0;
+  isolation: isolate;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+}
+
+.restArt {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  animation: campBreathe 20s ease-in-out infinite alternate;
+}
+
+.restStage[data-reduced='true'] .restArt {
+  animation: none;
+}
+
+.restCopy {
+  width: min(92%, 480px);
+  padding: clamp(20px, 5vw, 40px);
+  border-radius: 14px;
+  background: rgb(17 23 19 / .6);
+  backdrop-filter: blur(6px);
+  text-align: center;
+  color: #f4ead8;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes campBreathe {
+  from { transform: scale(1.01); }
+  to { transform: scale(1.03); }
+}
+
+@media (max-width: 720px) {
+  .silhouette {
+    bottom: 22%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .departureArt {
+    animation: none;
+  }
+
+  .beat {
+    transition: none;
+  }
+
+  .silhouette {
+    transition: none;
+  }
+
+  .restArt {
+    animation: none;
+  }
+}

--- a/app/quest/first-light/page.tsx
+++ b/app/quest/first-light/page.tsx
@@ -1,0 +1,37 @@
+import { redirect } from 'next/navigation'
+import { createSupabaseServerClient } from '../../../lib/supabase/server'
+import { FocusSessionRow } from '../../../lib/timer/first-light'
+import { QuestRunner } from './quest-runner'
+
+export const dynamic = 'force-dynamic'
+
+const FOCUS_SESSION_COLUMNS =
+  'id, status, started_at, duration_seconds, accumulated_ms, paused_at, completed_at, rewarded_at, rest_finished_at, chest_opened_at'
+
+export default async function FirstLightQuestPage() {
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) redirect('/account')
+
+  const { data: character } = await supabase
+    .from('characters')
+    .select('name')
+    .eq('profile_id', user.id)
+    .maybeSingle()
+
+  if (!character) redirect('/character')
+
+  const { data: session } = await supabase
+    .from('focus_sessions')
+    .select(FOCUS_SESSION_COLUMNS)
+    .eq('profile_id', user.id)
+    .eq('quest_key', 'ein-licht-im-unterholz')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle<FocusSessionRow>()
+
+  return <QuestRunner characterName={character.name} initialSession={session ?? null} />
+}

--- a/app/quest/first-light/quest-runner.tsx
+++ b/app/quest/first-light/quest-runner.tsx
@@ -1,0 +1,486 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createSupabaseBrowserClient } from '../../../lib/supabase/client'
+import { useSceneAudio } from '../../../lib/audio/use-scene-audio'
+import { useReducedMotion } from '../../../lib/hooks/use-reduced-motion'
+import { deriveQuestPhase, FocusSessionRow, toRestSession, toTimerSession } from '../../../lib/timer/first-light'
+import { formatRemaining, snapshot } from '../../../lib/timer/session'
+import { layerOffset } from '../../../lib/timer/journey'
+import styles from './first-light.module.css'
+
+type SupabaseClient = ReturnType<typeof createSupabaseBrowserClient>
+
+/**
+ * `.rpc()` without a generated `Database` type has no way to know a given
+ * function's return shape, and `.single()` only makes sense for a
+ * `returns table(...)` function (PostgREST answers those as an array).
+ * `start_first_light_session` & co. return a single `focus_sessions` row
+ * directly — PostgREST already answers with one JSON object, not an array —
+ * so this casts instead of risking a mismatched Accept header from `.single()`.
+ */
+async function callRpc<T>(
+  client: SupabaseClient,
+  fn: string,
+  args?: Record<string, unknown>,
+): Promise<{ data: T | null; error: { message: string } | null }> {
+  const result = await client.rpc(fn, args ?? {})
+  return result as unknown as { data: T | null; error: { message: string } | null }
+}
+
+const BEAT_COUNT = 4
+const AUDIO = {
+  departure: '/audio/audio-departure-motif-01.ogg',
+  focus: '/audio/audio-focus-light-undergrowth-01.ogg',
+  resolve: '/audio/audio-completion-resolve-01.ogg',
+  rest: '/audio/audio-rest-campfire-ambience-01.ogg',
+  chest: '/audio/sfx-chest-lantern-material-01.ogg',
+} as const
+
+type Stage = 'briefing' | 'departure' | 'focus' | 'resolution' | 'resting' | 'chest' | 'done'
+
+function beatIndexFor(progress: number): number {
+  return Math.min(BEAT_COUNT - 1, Math.floor(progress * BEAT_COUNT))
+}
+
+export function QuestRunner({
+  characterName,
+  initialSession,
+}: {
+  characterName: string
+  initialSession: FocusSessionRow | null
+}) {
+  const supabase = useMemo(() => createSupabaseBrowserClient(), [])
+  const reducedMotion = useReducedMotion()
+
+  const [session, setSession] = useState(initialSession)
+  const [departing, setDeparting] = useState(false)
+  const [restStartedAt, setRestStartedAt] = useState<number | null>(null)
+  const [reward, setReward] = useState<{ xp: number; gold: number } | null>(null)
+  const [woodAdded, setWoodAdded] = useState(false)
+  const [muted, setMuted] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
+  const [error, setError] = useState<string | null>(null)
+  const [liveMessage, setLiveMessage] = useState('')
+  const stageRef = useRef<HTMLDivElement | null>(null)
+  const completingRef = useRef(false)
+  const lastAnnouncedMinuteRef = useRef<number | null>(null)
+
+  const dbPhase = deriveQuestPhase(session)
+  const stage: Stage = departing
+    ? 'departure'
+    : dbPhase === 'resolution' && restStartedAt !== null
+      ? 'resting'
+      : dbPhase
+
+  // Eine Sekunde Auflösung reicht für einen Countdown; niemand braucht hier
+  // 60fps, und weniger Ticks schonen den Akku während der Fokuszeit.
+  useEffect(() => {
+    if (stage !== 'focus' && stage !== 'resting') return
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [stage])
+
+  const focusSnapshot = useMemo(() => {
+    if (!session || dbPhase !== 'focus') return null
+    return snapshot(toTimerSession(session), now)
+  }, [session, dbPhase, now])
+
+  const restSnapshot = useMemo(() => {
+    if (restStartedAt === null) return null
+    return snapshot(toRestSession(new Date(restStartedAt).toISOString()), now)
+  }, [restStartedAt, now])
+
+  const completeFocusSession = useCallback(async () => {
+    if (!session || completingRef.current) return
+    completingRef.current = true
+
+    const { data, error: rpcError } = await callRpc<
+      { xp: number; gold: number; chest_earned: boolean }[]
+    >(supabase, 'complete_first_light_session', { p_session_id: session.id })
+
+    completingRef.current = false
+
+    const row = data?.[0]
+    if (rpcError || !row) {
+      setError('Der Questabschluss konnte nicht gespeichert werden. Bitte versuch es gleich noch einmal.')
+      return
+    }
+
+    setReward({ xp: row.xp, gold: row.gold })
+    setSession((current) =>
+      current ? { ...current, status: 'completed', completed_at: new Date().toISOString(), rewarded_at: new Date().toISOString() } : current,
+    )
+  }, [session, supabase])
+
+  useEffect(() => {
+    if (focusSnapshot?.is_complete) {
+      void completeFocusSession()
+    }
+  }, [focusSnapshot?.is_complete, completeFocusSession])
+
+  // aria-live meldet Phasenwechsel und grobe 5-Minuten-Marken — nicht jede
+  // Sekunde. Screenreader-Nutzer:innen bekommen sonst einen Countdown vorgelesen.
+  useEffect(() => {
+    const announcements: Record<Stage, string> = {
+      briefing: '',
+      departure: 'Du brichst auf.',
+      focus: 'Fokus beginnt. Fünfzehn Minuten Weg liegen vor dir.',
+      resolution: 'Die Quest ist abgeschlossen.',
+      resting: 'Die Rast beginnt.',
+      chest: 'Deine Truhe ist bereit.',
+      done: 'Zurück im Lager.',
+    }
+    if (announcements[stage]) setLiveMessage(announcements[stage])
+    lastAnnouncedMinuteRef.current = null
+  }, [stage])
+
+  useEffect(() => {
+    if (!focusSnapshot || focusSnapshot.is_paused) return
+    const minutesLeft = Math.ceil(focusSnapshot.remaining_ms / 60000)
+    if (minutesLeft > 0 && minutesLeft % 5 === 0 && lastAnnouncedMinuteRef.current !== minutesLeft) {
+      lastAnnouncedMinuteRef.current = minutesLeft
+      setLiveMessage(`Noch ${minutesLeft} Minuten.`)
+    }
+  }, [focusSnapshot])
+
+  async function startDeparture() {
+    setError(null)
+    setDeparting(true)
+
+    const { data, error: rpcError } = await callRpc<FocusSessionRow>(supabase, 'start_first_light_session')
+
+    if (rpcError || !data) {
+      setDeparting(false)
+      setError('Der Aufbruch ist gerade nicht möglich. Bitte versuch es noch einmal.')
+      return
+    }
+
+    window.setTimeout(() => {
+      setSession(data)
+      setDeparting(false)
+    }, 4000)
+  }
+
+  async function togglePause() {
+    if (!session) return
+    const rpcName = focusSnapshot?.is_paused ? 'resume_focus_session' : 'pause_focus_session'
+    const { data, error: rpcError } = await callRpc<FocusSessionRow>(supabase, rpcName, { p_session_id: session.id })
+    if (!rpcError && data) setSession(data)
+  }
+
+  async function leaveQuest() {
+    if (!session) return
+    await callRpc(supabase, 'cancel_focus_session', { p_session_id: session.id })
+    window.location.href = '/camp'
+  }
+
+  async function finishRest() {
+    if (!session) return
+    const { data, error: rpcError } = await callRpc<string>(supabase, 'finish_first_light_rest', {
+      p_session_id: session.id,
+    })
+    if (rpcError || !data) return
+    setSession((current) => (current ? { ...current, rest_finished_at: data } : current))
+  }
+
+  useEffect(() => {
+    if (stage === 'resting' && restSnapshot?.is_complete) {
+      void finishRest()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stage, restSnapshot?.is_complete])
+
+  async function openChest() {
+    if (!session) return
+    const { error: rpcError } = await callRpc<boolean>(supabase, 'open_first_light_chest', {
+      p_session_id: session.id,
+    })
+    if (rpcError) return
+    setSession((current) => (current ? { ...current, chest_opened_at: new Date().toISOString() } : current))
+  }
+
+  async function toggleFullscreen() {
+    if (!stageRef.current) return
+    if (document.fullscreenElement) {
+      await document.exitFullscreen().catch(() => {})
+    } else {
+      await stageRef.current.requestFullscreen().catch(() => {})
+    }
+  }
+
+  useSceneAudio(AUDIO.departure, stage === 'departure', muted)
+  useSceneAudio(AUDIO.focus, stage === 'focus', muted)
+  useSceneAudio(AUDIO.rest, stage === 'resting', muted)
+
+  useEffect(() => {
+    if (stage !== 'resolution' || muted) return
+    new Audio(AUDIO.resolve).play().catch(() => {})
+  }, [stage, muted])
+
+  return (
+    <main id="main-content" className={styles.shell} ref={stageRef} data-stage={stage}>
+      <div role="status" aria-live="polite" className={styles.visuallyHidden}>
+        {liveMessage}
+      </div>
+
+      {error ? (
+        <p role="alert" className={styles.error}>
+          {error}
+        </p>
+      ) : null}
+
+      {stage === 'briefing' ? <Briefing onDepart={startDeparture} /> : null}
+      {stage === 'departure' ? <Departure /> : null}
+      {stage === 'focus' && focusSnapshot ? (
+        <FocusScene
+          snapshot={focusSnapshot}
+          reducedMotion={reducedMotion}
+          muted={muted}
+          onToggleMute={() => setMuted((value) => !value)}
+          onTogglePause={togglePause}
+          onLeave={leaveQuest}
+          onToggleFullscreen={toggleFullscreen}
+        />
+      ) : null}
+      {stage === 'resolution' ? (
+        <Resolution characterName={characterName} reward={reward} onContinue={() => setRestStartedAt(Date.now())} />
+      ) : null}
+      {stage === 'resting' && restSnapshot ? (
+        <Rest
+          snapshot={restSnapshot}
+          reducedMotion={reducedMotion}
+          woodAdded={woodAdded}
+          onAddWood={() => setWoodAdded(true)}
+          onSkip={finishRest}
+        />
+      ) : null}
+      {stage === 'chest' ? <ChestReady onOpen={openChest} /> : null}
+      {stage === 'done' ? <Done /> : null}
+    </main>
+  )
+}
+
+function Briefing({ onDepart }: { onDepart: () => void }) {
+  return (
+    <section className={styles.card} aria-labelledby="briefing-title">
+      <p className="eyebrow">Auftrag</p>
+      <h1 id="briefing-title">Ein Licht im Unterholz</h1>
+      <p>
+        Zwischen den Farnen flackert etwas. Fünfzehn ruhige Minuten reichen, um ihm ein Stück zu folgen — mehr
+        verlangt dieser Weg nicht von dir.
+      </p>
+      <button type="button" onClick={onDepart}>
+        Aufbrechen
+      </button>
+    </section>
+  )
+}
+
+function Departure() {
+  return (
+    <section className={styles.departure} aria-labelledby="departure-title">
+      <svg
+        viewBox="0 0 1600 900"
+        preserveAspectRatio="xMidYMid slice"
+        aria-hidden="true"
+        focusable="false"
+        className={styles.departureArt}
+      >
+        <use href="/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-01" />
+      </svg>
+      <div className={styles.departureCopy}>
+        <p className="eyebrow">Aufbruch</p>
+        <h1 id="departure-title">Du nimmst deine Ausrüstung und trittst zwischen die Bäume.</h1>
+      </div>
+    </section>
+  )
+}
+
+function FocusScene({
+  snapshot: snap,
+  reducedMotion,
+  muted,
+  onToggleMute,
+  onTogglePause,
+  onLeave,
+  onToggleFullscreen,
+}: {
+  snapshot: ReturnType<typeof snapshot>
+  reducedMotion: boolean
+  muted: boolean
+  onToggleMute: () => void
+  onTogglePause: () => void
+  onLeave: () => void
+  onToggleFullscreen: () => void
+}) {
+  const beat = beatIndexFor(snap.progress)
+  const silhouetteX = reducedMotion ? 0 : layerOffset(snap.progress, 120, 1)
+
+  return (
+    <section className={styles.focusStage} aria-labelledby="focus-title">
+      <div className={styles.beatLayer} aria-hidden="true">
+        {Array.from({ length: BEAT_COUNT }, (_, index) => (
+          <svg
+            key={index}
+            viewBox="0 0 1600 900"
+            preserveAspectRatio="xMidYMid slice"
+            focusable="false"
+            className={styles.beat}
+            data-active={index === beat}
+          >
+            <use href={`/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-0${index + 1}`} />
+          </svg>
+        ))}
+      </div>
+
+      <svg
+        viewBox="0 0 220 260"
+        aria-hidden="true"
+        focusable="false"
+        className={styles.silhouette}
+        style={{ transform: `translateX(${silhouetteX}px)` }}
+      >
+        <use href="/assets/phase1-art-pack.svg#journey-silhouette" />
+      </svg>
+
+      <div className={styles.timerPanel}>
+        <p className="eyebrow" id="focus-title">
+          Ein Licht im Unterholz
+        </p>
+        <p className={styles.timer} aria-hidden="true">
+          {formatRemaining(snap.remaining_ms)}
+        </p>
+        <div className={styles.controls}>
+          <button type="button" onClick={onTogglePause}>
+            {snap.is_paused ? 'Weiter' : 'Pause'}
+          </button>
+          <button type="button" onClick={onToggleMute} aria-pressed={muted}>
+            {muted ? 'Ton an' : 'Ton aus'}
+          </button>
+          <button type="button" onClick={onToggleFullscreen}>
+            Vollbild
+          </button>
+          <button type="button" className={styles.leave} onClick={onLeave}>
+            Quest verlassen
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function Resolution({
+  characterName,
+  reward,
+  onContinue,
+}: {
+  characterName: string
+  reward: { xp: number; gold: number } | null
+  onContinue: () => void
+}) {
+  return (
+    <section className={styles.card} aria-labelledby="resolution-title">
+      <svg viewBox="0 0 1600 900" aria-hidden="true" focusable="false" className={styles.resolutionArt}>
+        <use href="/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-04" />
+      </svg>
+      <p className="eyebrow">Questabschluss</p>
+      <h1 id="resolution-title">Das Licht ist erreicht.</h1>
+      <p>{characterName} bleibt einen Moment stehen. Genug für heute — der Weg zurück kann warten.</p>
+      <dl className={styles.rewardList}>
+        <div>
+          <dt>XP</dt>
+          <dd>+{reward?.xp ?? 15}</dd>
+        </div>
+        <div>
+          <dt>Gold</dt>
+          <dd>+{reward?.gold ?? 3}</dd>
+        </div>
+        <div>
+          <dt>Truhe</dt>
+          <dd>verdient — öffnet nach der Rast</dd>
+        </div>
+      </dl>
+      <button type="button" onClick={onContinue}>
+        Weiter zur Rast
+      </button>
+    </section>
+  )
+}
+
+function Rest({
+  snapshot: snap,
+  reducedMotion,
+  woodAdded,
+  onAddWood,
+  onSkip,
+}: {
+  snapshot: ReturnType<typeof snapshot>
+  reducedMotion: boolean
+  woodAdded: boolean
+  onAddWood: () => void
+  onSkip: () => void
+}) {
+  return (
+    <section className={styles.restStage} aria-labelledby="rest-title" data-reduced={reducedMotion} data-fed={woodAdded}>
+      <svg
+        viewBox="0 0 1600 900"
+        preserveAspectRatio="xMidYMid slice"
+        aria-hidden="true"
+        focusable="false"
+        className={styles.restArt}
+      >
+        <use href="/assets/phase1-art-pack.svg#rest-campfire" />
+      </svg>
+      <div className={styles.restCopy}>
+        <p className="eyebrow" id="rest-title">
+          Rast
+        </p>
+        <p>Das Feuer knistert. Es gibt gerade nichts zu tun, und das ist genau richtig so.</p>
+        <p className={styles.timer} aria-hidden="true">
+          {formatRemaining(snap.remaining_ms)}
+        </p>
+        <div className={styles.controls}>
+          {!woodAdded ? (
+            <button type="button" onClick={onAddWood}>
+              Holz auflegen
+            </button>
+          ) : null}
+          <button type="button" className={styles.leave} onClick={onSkip}>
+            Rast überspringen
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function ChestReady({ onOpen }: { onOpen: () => void }) {
+  return (
+    <section className={styles.card} aria-labelledby="chest-title">
+      <svg viewBox="0 0 1600 900" aria-hidden="true" focusable="false" className={styles.chestArt}>
+        <use href="/assets/phase1-art-pack.svg#chest-closed" />
+      </svg>
+      <p className="eyebrow">Nach der Rast</p>
+      <h1 id="chest-title">Deine erste Truhe wartet.</h1>
+      <button type="button" onClick={onOpen}>
+        Truhe öffnen
+      </button>
+    </section>
+  )
+}
+
+function Done() {
+  return (
+    <section className={styles.card} aria-labelledby="done-title">
+      <svg viewBox="0 0 1600 900" aria-hidden="true" focusable="false" className={styles.chestArt}>
+        <use href="/assets/phase1-art-pack.svg#chest-open" />
+      </svg>
+      <p className="eyebrow">Alte Weglaterne gefunden</p>
+      <h1 id="done-title">Der Weg zurück ist erhellt.</h1>
+      <p>Die Laterne steht ab jetzt in deinem Lager. Der Bildschirm hat für heute nichts mehr für dich.</p>
+      <Link href="/camp">Zurück ins Lager</Link>
+    </section>
+  )
+}

--- a/docs/PREVIEW-DEPLOYMENT.md
+++ b/docs/PREVIEW-DEPLOYMENT.md
@@ -85,11 +85,13 @@ Damit Magic-Link-/Auth-Callbacks funktionieren, muss die vom Webdesigner bereitg
 
 ## Aktueller Handoff-Stand
 
-Der Lager-Hub aus #29 / PR #57 ist in `main` enthalten. Der aktuelle Testpfad ist damit:
+Der komplette Vertical-Slice-Pfad ist in `main` enthalten. Der aktuelle Testpfad ist damit:
 
-**Waldintro → Account → Charakter → Lager**
+**Waldintro → Account → Charakter → Lager → Abenteuerbuch → Aufbruch → 15-Minuten-Fokus → Questabschluss → Rast → Truhe → Weglaterne im Lager**
 
-Der nächste Feature-Schritt #37 ergänzt anschließend das Abenteuerbuch.
+Damit ist der in #35 beschriebene Vertical Slice erstmals von vorn bis hinten durchspielbar. Migration `20260905090000_focus_session_pause.sql` muss vor dem Deployment auf die Supabase-Instanz angewendet werden (ergänzt Pause/Resume-Spalten und -Funktionen auf `focus_sessions`).
+
+Damit verbleibt für #35 nur noch die tatsächliche Browser-Abnahme durch den Project Lead — technisch ist der Pfad vollständig.
 
 ## Nicht Bestandteil dieses Handoffs
 

--- a/lib/audio/use-scene-audio.ts
+++ b/lib/audio/use-scene-audio.ts
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+/**
+ * Plays one looping ambience/music cue for as long as `active` is true.
+ * Audio must never block the focus flow (docs/PHASE1-ART-AUDIO-HANDOFF.md),
+ * so every failure — autoplay blocked, file missing, codec unsupported — is
+ * swallowed. Muted playback and a missing production audio file both look
+ * exactly like "quiet room," which is the correct fallback for a Fokus-Screen.
+ */
+export function useSceneAudio(src: string, active: boolean, muted: boolean) {
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+
+  useEffect(() => {
+    const audio = new Audio(src)
+    audio.loop = true
+    audio.preload = 'auto'
+    audio.addEventListener('error', () => {
+      // Missing/undelivered asset — stay silent, never surface a broken UI.
+    })
+    audioRef.current = audio
+
+    return () => {
+      audio.pause()
+      audio.src = ''
+      audioRef.current = null
+    }
+  }, [src])
+
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return
+    audio.muted = muted
+
+    if (active) {
+      audio.play().catch(() => {
+        // Autoplay policies or a 404 — silence is an acceptable fallback here.
+      })
+    } else {
+      audio.pause()
+    }
+  }, [active, muted])
+}

--- a/lib/hooks/use-reduced-motion.ts
+++ b/lib/hooks/use-reduced-motion.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Reads `prefers-reduced-motion` and stays in sync if the person changes it
+ * mid-session. CSS handles most of the actual motion reduction (see the
+ * `@media (prefers-reduced-motion: reduce)` blocks); this hook exists for the
+ * handful of decisions JS has to make anyway — which beat to render, whether
+ * to run a rAF loop at all.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false)
+
+  useEffect(() => {
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setReduced(query.matches)
+
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches)
+    query.addEventListener('change', onChange)
+    return () => query.removeEventListener('change', onChange)
+  }, [])
+
+  return reduced
+}

--- a/lib/timer/__tests__/first-light.test.ts
+++ b/lib/timer/__tests__/first-light.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { deriveQuestPhase, FocusSessionRow, toTimerSession } from '../first-light'
+import { snapshot } from '../session'
+
+const T0 = '2026-09-05T09:00:00.000Z'
+
+function row(overrides: Partial<FocusSessionRow> = {}): FocusSessionRow {
+  return {
+    id: 'session-1',
+    status: 'active',
+    started_at: T0,
+    duration_seconds: 900,
+    accumulated_ms: 0,
+    paused_at: null,
+    completed_at: null,
+    rewarded_at: null,
+    rest_finished_at: null,
+    chest_opened_at: null,
+    ...overrides,
+  }
+}
+
+describe('deriveQuestPhase', () => {
+  it('shows the briefing when there is no session yet', () => {
+    expect(deriveQuestPhase(null)).toBe('briefing')
+  })
+
+  it('treats a cancelled session like no session — no dead end', () => {
+    expect(deriveQuestPhase(row({ status: 'cancelled' }))).toBe('briefing')
+  })
+
+  it('is the focus screen while the session is active, paused or not', () => {
+    expect(deriveQuestPhase(row({ status: 'active' }))).toBe('focus')
+    expect(deriveQuestPhase(row({ status: 'active', paused_at: T0 }))).toBe('focus')
+  })
+
+  it('moves through resolution, rest and the chest before done', () => {
+    const completed = row({ status: 'completed', completed_at: T0, rewarded_at: T0 })
+    expect(deriveQuestPhase(completed)).toBe('resolution')
+    expect(deriveQuestPhase({ ...completed, rest_finished_at: T0 })).toBe('chest')
+    expect(deriveQuestPhase({ ...completed, rest_finished_at: T0, chest_opened_at: T0 })).toBe('done')
+  })
+})
+
+describe('toTimerSession', () => {
+  it('carries the accumulated pause time into the reusable timer snapshot', () => {
+    const session = toTimerSession(
+      row({ started_at: T0, accumulated_ms: 30_000, paused_at: T0 }),
+    )
+    const state = snapshot(session, Date.parse(T0) + 60_000)
+
+    // paused_at is set, so elapsed stays frozen at the accumulated amount
+    // regardless of how much wall-clock time passes.
+    expect(state.elapsed_ms).toBe(30_000)
+    expect(state.is_paused).toBe(true)
+  })
+
+  it('keeps counting from accumulated_ms once resumed', () => {
+    const session = toTimerSession(
+      row({ started_at: T0, accumulated_ms: 30_000, paused_at: null }),
+    )
+    const state = snapshot(session, Date.parse(T0) + 10_000)
+
+    expect(state.elapsed_ms).toBe(40_000)
+  })
+})

--- a/lib/timer/first-light.ts
+++ b/lib/timer/first-light.ts
@@ -1,0 +1,61 @@
+/**
+ * "Ein Licht im Unterholz" — Ableitung des UI-Zustands aus dem
+ * `focus_sessions`-Datensatz. Reine Funktionen, kein React, kein Date.now():
+ * dieselbe Grundregel wie in session.ts und journey.ts. Das ist, was einen
+ * Reload oder einen Hintergrund-Tab automatisch korrekt macht — es gibt
+ * keinen zweiten, clientseitigen Zustand, der aus dem Tritt geraten könnte.
+ */
+
+import { PHASE_ONE_DURATIONS, TimerSession } from './session'
+
+export type FocusSessionStatus = 'active' | 'completed' | 'cancelled'
+
+export interface FocusSessionRow {
+  id: string
+  status: FocusSessionStatus
+  started_at: string
+  duration_seconds: number
+  accumulated_ms: number
+  paused_at: string | null
+  completed_at: string | null
+  rewarded_at: string | null
+  rest_finished_at: string | null
+  chest_opened_at: string | null
+}
+
+export type QuestPhase = 'briefing' | 'focus' | 'resolution' | 'chest' | 'done'
+
+/**
+ * Welche Phase die Oberfläche gerade zeigen muss. `departure` kommt hier nie
+ * heraus — das kurze Aufbruchsritual ist rein clientseitige Inszenierung
+ * *bevor* die Session existiert und wird vom aufrufenden Code selbst gesteuert.
+ */
+export function deriveQuestPhase(session: FocusSessionRow | null): QuestPhase {
+  if (!session || session.status === 'cancelled') return 'briefing'
+  if (session.status === 'active') return 'focus'
+
+  // status === 'completed'
+  if (session.chest_opened_at) return 'done'
+  if (session.rest_finished_at) return 'chest'
+  return 'resolution'
+}
+
+export function toTimerSession(session: FocusSessionRow): TimerSession {
+  return {
+    phase: 'focus',
+    duration_s: session.duration_seconds,
+    started_at: session.started_at,
+    accumulated_ms: session.accumulated_ms,
+    paused_at: session.paused_at,
+  }
+}
+
+export function toRestSession(restStartedAt: string): TimerSession {
+  return {
+    phase: 'rest',
+    duration_s: PHASE_ONE_DURATIONS.rest_s,
+    started_at: restStartedAt,
+    accumulated_ms: 0,
+    paused_at: null,
+  }
+}

--- a/supabase/migrations/20260905090000_focus_session_pause.sql
+++ b/supabase/migrations/20260905090000_focus_session_pause.sql
@@ -1,0 +1,160 @@
+-- Adds pause/resume support to the phase-1 focus session, mirroring the
+-- already-tested accumulated_ms algebra in lib/timer/session.ts. Required by
+-- #12 ("Steuerung: Pause"): without server-authoritative pause, a reload
+-- during a pause would silently resume counting down.
+
+alter table public.focus_sessions
+  add column paused_at timestamptz,
+  add column accumulated_ms bigint not null default 0 check (accumulated_ms >= 0);
+
+create or replace function public.pause_focus_session(p_session_id uuid)
+returns public.focus_sessions
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_session public.focus_sessions%rowtype;
+begin
+  if v_user_id is null then
+    raise exception 'authentication required';
+  end if;
+
+  select * into v_session
+  from public.focus_sessions fs
+  where fs.id = p_session_id and fs.profile_id = v_user_id
+  for update;
+
+  if not found then
+    raise exception 'session not found';
+  end if;
+
+  if v_session.status <> 'active' then
+    raise exception 'only an active session can be paused';
+  end if;
+
+  if v_session.paused_at is null then
+    update public.focus_sessions fs
+    set accumulated_ms = fs.accumulated_ms
+        + greatest(0, floor(extract(epoch from (now() - fs.started_at)) * 1000))::bigint,
+        paused_at = now()
+    where fs.id = p_session_id
+    returning * into v_session;
+  end if;
+
+  return v_session;
+end;
+$$;
+
+create or replace function public.resume_focus_session(p_session_id uuid)
+returns public.focus_sessions
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_session public.focus_sessions%rowtype;
+begin
+  if v_user_id is null then
+    raise exception 'authentication required';
+  end if;
+
+  select * into v_session
+  from public.focus_sessions fs
+  where fs.id = p_session_id and fs.profile_id = v_user_id
+  for update;
+
+  if not found then
+    raise exception 'session not found';
+  end if;
+
+  if v_session.status <> 'active' then
+    raise exception 'only an active session can be resumed';
+  end if;
+
+  if v_session.paused_at is not null then
+    update public.focus_sessions fs
+    set started_at = now(),
+        paused_at = null
+    where fs.id = p_session_id
+    returning * into v_session;
+  end if;
+
+  return v_session;
+end;
+$$;
+
+-- complete_first_light_session compared `now()` against
+-- `started_at + duration`, which ignored accumulated_ms and paused time.
+-- Recreated here so a pause no longer lets the quest finish early or forces
+-- the person to wait out time they already spent paused.
+create or replace function public.complete_first_light_session(p_session_id uuid)
+returns table (xp integer, gold integer, chest_earned boolean)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_session public.focus_sessions%rowtype;
+  v_elapsed_ms bigint;
+begin
+  if v_user_id is null then
+    raise exception 'authentication required';
+  end if;
+
+  select * into v_session
+  from public.focus_sessions fs
+  where fs.id = p_session_id and fs.profile_id = v_user_id
+  for update;
+
+  if not found then
+    raise exception 'session not found';
+  end if;
+
+  if v_session.quest_key <> 'ein-licht-im-unterholz' or v_session.duration_seconds <> 900 then
+    raise exception 'session is not the phase 1 quest';
+  end if;
+
+  if v_session.status = 'active' then
+    v_elapsed_ms := v_session.accumulated_ms;
+    if v_session.paused_at is null then
+      v_elapsed_ms := v_elapsed_ms
+        + greatest(0, floor(extract(epoch from (now() - v_session.started_at)) * 1000))::bigint;
+    end if;
+
+    if v_elapsed_ms < v_session.duration_seconds::bigint * 1000 then
+      raise exception 'focus duration not yet elapsed';
+    end if;
+
+    update public.focus_sessions fs
+    set status = 'completed', completed_at = now()
+    where fs.id = p_session_id;
+  elsif v_session.status <> 'completed' then
+    raise exception 'session is not completable';
+  end if;
+
+  if v_session.rewarded_at is null then
+    update public.profiles p
+    set xp = p.xp + 15,
+        gold = p.gold + 3
+    where p.id = v_user_id;
+
+    update public.focus_sessions fs
+    set rewarded_at = now()
+    where fs.id = p_session_id and fs.rewarded_at is null;
+  end if;
+
+  return query
+  select p.xp, p.gold, true
+  from public.profiles p
+  where p.id = v_user_id;
+end;
+$$;
+
+revoke all on function public.pause_focus_session(uuid) from public;
+revoke all on function public.resume_focus_session(uuid) from public;
+grant execute on function public.pause_focus_session(uuid) to authenticated;
+grant execute on function public.resume_focus_session(uuid) to authenticated;


### PR DESCRIPTION
## Ziel
Vervollständigt den in #35 beschriebenen kritischen Pfad bis zur End-to-End-Abnahme: Auftrag → Aufbruch → 15-Minuten-Fokus mit Journey → Questabschluss → Rast → Truhe → Weglaterne im Lager.

Closes #38
Closes #12
Closes #21
Closes #13
Closes #39

## Warum ein PR für fünf Issues
#35 verlangt ausdrücklich, #38/#12/#21 koordiniert umzusetzen ("damit keine getrennten Wahrheiten für Timer, Journey und Narrative entstehen"). #13 und #39 hängen direkt daran — ohne sie wäre #38s eigenes Akzeptanzkriterium "Übergang zu #13 ohne Sackgasse" nicht erfüllbar. Alle fünf teilen sich einen Screen und einen Session-Zustand.

## Technischer Ansatz
- `lib/timer/first-light.ts`: `deriveQuestPhase()` liest die UI-Phase ausschließlich aus dem `focus_sessions`-Datensatz. Kein Reload-Sonderfall nötig — Reload liefert einfach denselben Datensatz erneut.
- **Migration `20260905090000_focus_session_pause.sql`**: ergänzt `paused_at`/`accumulated_ms` auf `focus_sessions` sowie `pause_focus_session`/`resume_focus_session`. Die Pause-Algebra lag in `lib/timer/session.ts` bereits fertig und getestet, war aber nie an eine Spalte angebunden — #12 verlangt einen echten Pause-Control, kein rein visuelles Einfrieren. `complete_first_light_session` wurde entsprechend neu erstellt, damit pausierte Zeit nicht mitzählt.
- Journey-Kulisse: vier vorhandene Beat-Assets aus dem Phase-1-Artpaket, Auswahl und Parallaxe rein aus `snapshot.progress` abgeleitet (`layerOffset` aus `lib/timer/journey.ts`).
- `aria-live` meldet nur Phasenwechsel und 5-Minuten-Marken.
- Reduced Motion: Crossfades/Parallaxe/Atmen-Animation aus, inhaltlicher Fortschritt (welcher Beat aktiv ist) bleibt erhalten.
- Audio ist best-effort verdrahtet, blockiert nie den Ablauf.

## Bekannte Lücke — bitte bei der Abnahme beachten
Die in `docs/PHASE1-ART-AUDIO-HANDOFF.md` gelisteten sechs Audio-Dateien liegen **nicht** im Repository, obwohl #40/#41 als abgeschlossen geschlossen wurden. Der Code behandelt ein 404 hier bewusst lautlos (kein Absturz, keine blockierte Fokusphase), aber die Quest ist damit aktuell stumm. Das ist kein Bug in diesem PR, sondern eine Lücke aus #40 — ich eröffne dazu ein separates Issue.

## Verifikation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (93/93, inkl. 6 neue Tests für `deriveQuestPhase`/`toTimerSession`)
- [x] `npm run build`
- [ ] **Kein Browser-Durchklick möglich** — es gibt keine echte Supabase-Projektkonfiguration in dieser Session (nur Platzhalter-Env für den Build), daher kein Magic-Link-Login testbar. Die eigentliche Produkt-/Art-Abnahme im Browser bleibt bei #35 und hängt an #51.

## Rollout-Hinweis
Migration `20260905090000_focus_session_pause.sql` muss vor dem nächsten Preview-/Prod-Deployment auf die Supabase-Instanz angewendet werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)