### PR TITLE
#SENDEV title-labels Action: '#' im Label-Namen erhalten

### DIFF
--- a/.github/workflows/title-labels.yml
+++ b/.github/workflows/title-labels.yml
@@ -23,7 +23,7 @@ jobs:
 
             const title = item.title || "";
             const known = ["#SENDEV", "#junDev", "#release"];
-            const wanted = known.filter((tag) => title.includes(tag)).map((t) => t.slice(1));
+            const wanted = known.filter((tag) => title.includes(tag));
 
             if (wanted.length === 0) return;
 


### PR DESCRIPTION
## Problem
Der in PR #63 eingeführte Label-Automatismus hat das führende `#` vom Titel-Hashtag abgeschnitten, bevor er es als Label gesetzt hat. Die tatsächlichen Labels heißen aber `#SENDEV`/`#junDev`/`#release` (siehe docs/WORKFLOW.md). Ergebnis: neue, falsche Label-Definitionen `SENDEV`/`junDev` wurden automatisch angelegt und auf PR #65 sowie Issue #66 gesetzt.

## Fix
Ein Zeichen — `.map((t) => t.slice(1))` entfernt.

## Bereits manuell nachgezogen (nicht Teil dieses PRs, zur Nachvollziehbarkeit)
- PR #64, #65 und Issue #66 auf die korrekten `#`-Labels korrigiert
- Die drei fälschlich erzeugten Label-Definitionen (`release`, `junDev`, `SENDEV` ohne `#`) gelöscht

## Verifikation
Diese Änderung betrifft nur Workflow-YAML, keinen App-Code — Build/Test/Lint sind unverändert grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)