### PR TITLE
#SENDEV #release ADR-038: Render.com als befristete Dev-Preview

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -69,11 +69,19 @@ Drei persistente Akte mit Rasten; Boss/Höhepunkt in Akt III. Kein 90-Minuten-Da
 **Grund:** Die vorhandene Infrastruktur und Ziel-Domain sollen konsistent dokumentiert werden, ohne unbestätigte Hostinger-Runtime-Eigenschaften oder einen vorzeitigen Produktions-Cutover anzunehmen.
 
 ### ADR-037 · Preview-Deployment ebenfalls ausschließlich über Hostinger, kein Vercel-Runner
-**Status:** angenommen · 2026-09-05  
+**Status:** **teilweise geändert durch ADR-038** (befristete Dev-Preview-Ausnahme) · 2026-09-05  
 **Kontext:** Für #51 wurde zwischenzeitlich ein GitHub-Actions-Workflow vorbereitet, der einen Vercel-Preview-Runner voraussetzt (`VERCEL_TOKEN`/`VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` als GitHub-Environment-Secrets). Das widerspricht sowohl `docs/PREVIEW-DEPLOYMENT.md` ("kein Vercel, kein automatisches Deployment aus GitHub Actions") als auch ADR-036, das Hostinger bereits als Produktionsziel festlegt.  
 **Entscheidung:** Auch der interne Preview-Stand für #51 läuft ausschließlich über den vom Webdesigner betreuten Hostinger-Teststand, wie in `docs/PREVIEW-DEPLOYMENT.md` beschrieben. Kein Vercel-Pfad, keine Vercel-Credentials als Voraussetzung, kein automatisches GitHub-Actions-Deployment. Der zwischenzeitlich vorbereitete Vercel-Workflow gilt als obsolet.  
 **Alternative:** Vercel als separater, schnellerer Preview-Runner neben der Hostinger-Produktion.  
 **Grund:** Zwei parallele Hosting-Pfade (Vercel für Preview, Hostinger für Produktion) erzeugen doppelte Environment-Pflege und ein Preview, das sich vom späteren Produktions-Runtime unterscheidet — genau das Risiko, das #51 eigentlich absichern soll.
+
+### ADR-038 · Render.com als befristete Dev-Preview, SteerCo-Entscheidung wegen Hostinger-Kosten
+**Status:** angenommen · 2026-09-06  
+**Kontext:** Hostingers Node.js-Hosting-Produkt (Voraussetzung für #51, siehe ADR-037/#58) kostet bei monatlicher Laufzeit **18 €/Monat**; der beworbene Preis von 3,99 €/Monat gilt nur bei 48 Monaten Vertragsbindung. Für die aktive, noch unabgeschlossene Entwicklungsphase ist weder die laufende Kostenhöhe noch eine 48-Monats-Bindung angemessen. Diese Kostenfrage wurde im SteerCo besprochen.  
+**Entscheidung:** Für die Dauer der aktiven Entwicklungsphase läuft der interne Preview-Stand für #51 auf **Render.com (Free-Tier)** statt auf Hostinger — echtes Node.js (`npm run build` / `npm run start`, siehe `render.yaml`), kein Vertrags-Lock-in, keine laufenden Kosten. Diese Ausnahme ist **befristet**: Sobald der Produktions-Cutover ansteht (Issue #3), wird auf Hostinger als Produktionsziel umgestellt — daran ändert diese Entscheidung nichts. ADR-036 (Hostinger als Produktionsziel) bleibt vollständig in Kraft. Der in ADR-037 festgehaltene Vercel-Ausschluss bleibt ebenfalls in Kraft — Render wurde bewusst gewählt, weil es echtes Node.js statt einer Edge-Runtime bereitstellt und damit näher an der Ziel-Produktionsumgebung liegt als ein Edge-/Workers-basierter Anbieter.  
+**Alternative 1:** Hostinger Node.js-Hosting sofort buchen (18 €/Monat oder 48-Monats-Bindung) — abgelehnt wegen der Kosten während einer noch offenen Entwicklungsphase ohne festen Zeitrahmen.  
+**Alternative 2:** Cloudflare Pages/Workers (ebenfalls kostenlos) — abgelehnt, weil es auf einer Edge-Runtime statt Node.js läuft und damit stärker von der Ziel-Produktionsumgebung abweicht als Render.  
+**Grund:** Kostenkontrolle während der Entwicklungsphase, ohne die Produktionsentscheidung (Hostinger, ADR-036) oder den Vercel-Ausschluss (ADR-037) aufzugeben. Setup-Details: `docs/PREVIEW-DEPLOYMENT.md`, Abschnitt "Render (befristete Dev-Preview)".
 
 ---
 

--- a/docs/PREVIEW-DEPLOYMENT.md
+++ b/docs/PREVIEW-DEPLOYMENT.md
@@ -1,6 +1,11 @@
-# Internes Phase-1-Preview auf Hostinger
+# Internes Phase-1-Preview
 
-Dieses Dokument ist der technische Handoff für den Webdesigner. Der Developer bereitet den deploybaren Stand im Repository vor; der eigentliche Push bzw. das Deployment auf Hostinger wird durch den Webdesigner durchgeführt.
+> **Aktueller Preview-Pfad: Render.com (befristete Dev-Preview, ADR-038).**
+> Produktionsziel bleibt Hostinger / `focus.lang-jamin.de` (ADR-036) — daran ändert
+> die Render-Übergangslösung nichts. Sobald der Produktions-Cutover ansteht
+> (Issue #3), wird auf Hostinger als tatsächliches Deployment-Ziel umgestellt.
+
+Dieses Dokument ist der technische Handoff für den internen Preview-Stand. Der Developer bereitet den deploybaren Stand im Repository vor; die Einrichtung des jeweiligen Hosting-Accounts erfolgt durch die dafür zuständige Person (aktuell: Render-Account-Einrichtung, später: Webdesigner für Hostinger).
 
 ## Ziel
 
@@ -13,16 +18,16 @@ Das ist **kein öffentlicher Produktiv-Release** und ersetzt nicht das spätere 
 ### Developer / Technical Setup
 
 - hält `main` buildbar und CI-grün,
-- liefert die für Hostinger nötigen Build-/Start-Kommandos,
+- liefert die für den jeweiligen Preview-Host nötigen Build-/Start-Kommandos (`render.yaml` für Render),
 - dokumentiert die benötigten Environment-Variablen,
 - legt keine Secrets im Repository ab,
 - dokumentiert, welcher Commit/`main`-Stand deployt werden soll.
 
-### Webdesigner
+### Account-Owner (Render bzw. Webdesigner für Hostinger)
 
-- übernimmt den tatsächlichen Push bzw. das Deployment auf Hostinger,
-- richtet dort die Laufzeit/Umgebung ein,
-- hinterlegt die Preview-/Test-Environment-Variablen serverseitig,
+- übernimmt die tatsächliche Account-/Service-Einrichtung,
+- hinterlegt die Preview-/Test-Environment-Variablen serverseitig (nie im Repo),
+- trägt die Preview-URL als Supabase-Auth-Redirect ein,
 - stellt die Browser-URL bereit,
 - meldet Deployment- oder Laufzeitfehler zurück.
 
@@ -48,7 +53,7 @@ npm run build
 npm run start
 ```
 
-Für den Hostinger-Teststand muss die dort genutzte Node.js-Laufzeit mit der Next.js-Version des Projekts kompatibel sein. Vor einem späteren Produktions-Cutover bleibt die vollständige Hostinger-Laufzeitqualifikation Bestandteil von Issue #3.
+`next start` liest den `PORT`, den der jeweilige Host vorgibt, automatisch — keine Code-Anpassung nötig.
 
 ## Benötigte Environment-Variablen
 
@@ -60,7 +65,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY
 NEXT_PUBLIC_SITE_URL
 ```
 
-`NEXT_PUBLIC_SITE_URL` muss auf die konkrete interne Hostinger-Test-URL gesetzt werden.
+`NEXT_PUBLIC_SITE_URL` muss auf die konkrete Preview-URL des jeweiligen Hosts gesetzt werden.
 
 Falls serverseitige Funktionen später einen Service-Role-Key benötigen, darf dieser ausschließlich serverseitig gesetzt werden:
 
@@ -72,16 +77,42 @@ Dieser Wert darf niemals im Client, Build-Output oder Repository erscheinen.
 
 ## Supabase Auth
 
-Damit Magic-Link-/Auth-Callbacks funktionieren, muss die vom Webdesigner bereitgestellte Hostinger-Test-URL in Supabase Auth als erlaubtes Redirect-Ziel hinterlegt werden. Der Callback-Pfad der Anwendung bleibt `/auth/callback`.
+Damit Magic-Link-/Auth-Callbacks funktionieren, muss die jeweilige Preview-URL in Supabase Auth als erlaubtes Redirect-Ziel hinterlegt werden. Der Callback-Pfad der Anwendung bleibt `/auth/callback`.
 
-## Ablauf nach neuen Phase-1-Merges
+Unabhängig vom Hosting-Pfad muss vor dem ersten Test die Migration `20260905090000_focus_session_pause.sql` auf die Supabase-Instanz angewendet werden (ergänzt Pause/Resume auf `focus_sessions`).
 
-1. Nur freigegebene Änderungen nach `main` mergen.
-2. CI auf `main` prüfen.
-3. Webdesigner erhält den aktuellen `main`-Stand bzw. Commit-SHA als Deployment-Quelle.
-4. Webdesigner aktualisiert den Hostinger-Teststand.
-5. Browser-URL prüfen: Startseite, Account, Charakter und Lager müssen erreichbar sein.
-6. Project Lead führt die Produkt-/Art-Abnahme im Browser durch.
+---
+
+## Render (befristete Dev-Preview, ADR-038)
+
+Grund für diesen Pfad: Hostingers Node.js-Hosting-Produkt kostet bei monatlicher Laufzeit 18 €/Monat (der beworbene 3,99-€-Preis gilt nur bei 48 Monaten Bindung) — für die laufende Entwicklungsphase unverhältnismäßig. Details siehe ADR-038 in `docs/DECISIONS.md`.
+
+Setup (einmalig, durch den Account-Owner):
+
+1. Kostenlosen Account auf render.com anlegen, per "Sign in with GitHub".
+2. Repository `yamahabenny-gif/pomodoro-dnd` autorisieren.
+3. "New Web Service" → Repo auswählen, Branch `main`. Render erkennt `render.yaml` im Repo-Root automatisch als Blueprint; alternativ manuell:
+   - Build Command: `npm ci && npm run build`
+   - Start Command: `npm run start`
+   - Instance Type: **Free**
+4. Die drei `NEXT_PUBLIC_*`-Variablen (siehe oben) im Render-Dashboard eintragen — `render.yaml` fragt danach (`sync: false`), committet aber keine Werte.
+5. `NEXT_PUBLIC_SITE_URL` auf die von Render vergebene URL setzen (Format `https://<service-name>.onrender.com`).
+6. Diese URL + `/auth/callback` als Supabase-Auth-Redirect eintragen.
+7. Auto-Deploy bei Push auf `main` kann aktiv bleiben — `main` ist durch Pflicht-CI geschützt.
+
+Bekannte Einschränkung: Der Free-Tier schläft nach ca. 15 Minuten Inaktivität; der nächste Aufruf braucht dann ~30–60 Sekunden zum Aufwachen. Für eine interne Abnahme ist das kein Blocker.
+
+Sichtbarkeit: Die `onrender.com`-URL ist technisch öffentlich erreichbar, aber unverlinkt/nicht auffindbar. Falls ein härterer Zugriffsschutz gewünscht ist, kann eine einfache HTTP-Basic-Auth-Middleware ergänzt werden — dafür bitte ein eigenes Issue anlegen, das ist aktuell nicht Teil dieses Handoffs.
+
+---
+
+## Hostinger (Produktionsziel, ADR-036 — aktuell nicht der Preview-Pfad)
+
+Für den späteren Produktions-Cutover (Issue #3) bleibt Hostinger das Ziel. Die Laufzeitqualifikation dafür ist in `docs/HOSTINGER-RUNTIME-QUALIFICATION.md` dokumentiert; der offene Punkt daraus (konkretes Node.js-Web-App-Produkt im hPanel) ist in #51 nachgetragen.
+
+Sobald der Cutover ansteht, gilt für Hostinger derselbe Build-/Start-Vertrag (`npm run build` / `npm run start`) und dieselbe Environment-Variablen-Liste wie oben.
+
+---
 
 ## Aktueller Handoff-Stand
 
@@ -91,11 +122,11 @@ Der komplette Vertical-Slice-Pfad ist in `main` enthalten. Der aktuelle Testpfad
 
 Damit ist der in #35 beschriebene Vertical Slice erstmals von vorn bis hinten durchspielbar. Migration `20260905090000_focus_session_pause.sql` muss vor dem Deployment auf die Supabase-Instanz angewendet werden (ergänzt Pause/Resume-Spalten und -Funktionen auf `focus_sessions`).
 
-Damit verbleibt für #35 nur noch die tatsächliche Browser-Abnahme durch den Project Lead — technisch ist der Pfad vollständig.
+Damit verbleibt für #35 nur noch die tatsächliche Browser-Abnahme durch den Project Lead — technisch ist der Pfad vollständig. Die Render-Account-Einrichtung steht noch aus (siehe oben).
 
 ## Nicht Bestandteil dieses Handoffs
 
-- kein Vercel
+- kein Vercel (ADR-037 bleibt in Kraft)
 - kein automatisches Deployment aus GitHub Actions
 - keine produktive DNS-/Domain-Umschaltung
 - keine Veröffentlichung als öffentlicher Release
@@ -103,4 +134,4 @@ Damit verbleibt für #35 nur noch die tatsächliche Browser-Abnahme durch den Pr
 
 ## Erfolgskriterium für #51
 
-#51 ist technisch erst dann vollständig abgeschlossen, wenn der Webdesigner diesen vorbereiteten Stand tatsächlich auf Hostinger bereitgestellt und eine funktionierende Browser-URL zurückgemeldet hat. Der Repo-Anteil des Developers besteht in einem sauberen, dokumentierten und deploybaren Handoff.
+#51 ist technisch erst dann vollständig abgeschlossen, wenn der aktuelle `main`-Stand tatsächlich auf Render bereitgestellt und eine funktionierende Browser-URL zurückgemeldet wurde. Der Repo-Anteil des Developers besteht in einem sauberen, dokumentierten und deploybaren Handoff (dieses Dokument + `render.yaml`).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/render.yaml
+++ b/render.yaml
@@ -7,13 +7,14 @@
 # Render-Dashboard. Dies ersetzt nicht das Produktionsziel Hostinger
 # (ADR-036) — siehe docs/PREVIEW-DEPLOYMENT.md.
 #
-# Unverifiziert gegen einen echten Render-Account: bitte beim ersten Setup
-# gegen das aktuelle Render-Blueprint-Schema prüfen (https://render.com/docs/blueprint-spec).
+# Geprüft gegen die aktuelle Render-Blueprint-Spec durch Technical-Owner-Review
+# auf PR #70 (https://render.com/docs/blueprint-spec) — `env:` ist dort veraltet,
+# `runtime:` ist das aktuelle, erforderliche Feld.
 
 services:
   - type: web
     name: pomodoro-dnd-preview
-    env: node
+    runtime: node
     plan: free
     branch: main
     buildCommand: npm ci && npm run build

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,29 @@
+# Render Blueprint für den befristeten Dev-/Preview-Stand aus ADR-038.
+#
+# Damit steht die Service-Konfiguration im Repo statt nur im Render-Dashboard
+# (docs/WORKFLOW.md: "Ergebnisse ins Repo schreiben, nicht nur in den Chat").
+# Secrets/Werte selbst stehen NICHT hier — `sync: false` bedeutet, Render
+# fragt beim ersten Setup danach und die Werte bleiben ausschließlich im
+# Render-Dashboard. Dies ersetzt nicht das Produktionsziel Hostinger
+# (ADR-036) — siehe docs/PREVIEW-DEPLOYMENT.md.
+#
+# Unverifiziert gegen einen echten Render-Account: bitte beim ersten Setup
+# gegen das aktuelle Render-Blueprint-Schema prüfen (https://render.com/docs/blueprint-spec).
+
+services:
+  - type: web
+    name: pomodoro-dnd-preview
+    env: node
+    plan: free
+    branch: main
+    buildCommand: npm ci && npm run build
+    startCommand: npm run start
+    envVars:
+      - key: NODE_VERSION
+        value: 22.11.0
+      - key: NEXT_PUBLIC_SUPABASE_URL
+        sync: false
+      - key: NEXT_PUBLIC_SUPABASE_ANON_KEY
+        sync: false
+      - key: NEXT_PUBLIC_SITE_URL
+        sync: false


### PR DESCRIPTION
## Ziel
Bereitet die Repo-Seite für #51 auf Render.com vor — SteerCo-Entscheidung wegen Hostinger-Kosten (18 €/Monat bei monatlicher Laufzeit statt der beworbenen 3,99 €, die nur bei 48 Monaten Bindung gelten).

## Änderungen
- **ADR-038** in `docs/DECISIONS.md`: Render als befristete Dev-Preview, Hostinger bleibt Produktionsziel (ADR-036 unverändert), Vercel-Ausschluss (ADR-037) bleibt in Kraft. ADR-037 als "teilweise geändert" markiert.
- **`render.yaml`**: Blueprint für den Render-Service. Enthält keine Secret-Werte, nur Variablennamen (`sync: false`) — Render fragt beim Setup danach.
- **`package.json`**: `engines.node: 22.x` ergänzt, passend zur CI-Node-Version.
- **`docs/PREVIEW-DEPLOYMENT.md`**: neuer Abschnitt "Render (befristete Dev-Preview, ADR-038)" mit konkreter Setup-Anleitung; Hostinger-Abschnitt bleibt als Produktionsziel-Referenz erhalten.

## Kein App-Code verändert
Reine Config-/Doku-Änderung. `next.config.mjs` brauchte keine Anpassung — kein Static Export, `next start` liest `PORT` automatisch.

## Account-Einrichtung folgt separat
Dieser PR bereitet nur die Repo-Seite vor. Die eigentliche Render-Account-/Service-Einrichtung sowie das Eintragen der Environment-Variablen erfolgt separat durch den Account-Owner — danach ist #51 browser-testbar.

## Verifikation
- [x] `npm run typecheck`
- [x] `npm run lint` (2 vorbestehende, unveränderte Warnings — keine Fehler)
- [x] `npm test` (93/93)
- [x] `npm run build`
- [ ] `render.yaml` ist unverifiziert gegen einen echten Render-Account — beim ersten Setup gegen das aktuelle Blueprint-Schema prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)