### PR TITLE
#SENDEV Loot- und Reward-Logik auf Concept V2 (ADR-021, ADR-030) migrieren

### DIFF
--- a/content/items.de.json
+++ b/content/items.de.json
@@ -282,210 +282,210 @@
   {
     "id": "cha-sel-zunftmantel",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Zunftmantel",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-kettenhaube",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Kettenhaube",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-marschstiefel",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Marschstiefel",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-silbergurt",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Silbergurt",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-reiherfeder-kappe",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Reiherfeder-Kappe",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-regenumhang",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Regenumhang",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-panzerhandschuh",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Panzerhandschuh",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-leinenscharpe",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Leinenschärpe",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-buckelschild",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Buckelschild",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-eibenstab",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Eibenstab",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-silberring",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Silberring",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-schienbeinschutz",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Schienbeinschutz",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-brustharnisch",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Brustharnisch",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-kartenrolle",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Kartenrolle",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-gurteltasche",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Gürteltasche",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-bernsteinamulett",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Bernsteinamulett",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-zunftklinge",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Zunftklinge",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-kapuzenhut",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Kapuzenhut",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-schuppengurt",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Schuppengurt",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-sel-armschienen",
     "category": "charakter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Armschienen",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
     "id": "cha-epi-zwielichtmantel",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Zwielichtmantel",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
     "id": "cha-epi-mondsteinhelm",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Mondsteinhelm",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
     "id": "cha-epi-nebelganger",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Nebelgänger",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
     "id": "cha-epi-sternengurt",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Sternengurt",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
     "id": "cha-epi-schwingenkappe",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Schwingenkappe",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
     "id": "cha-epi-aschenumhang",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Aschenumhang",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
     "id": "cha-epi-frostgriff",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Frostgriff",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
     "id": "cha-epi-glutscharpe",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Glutschärpe",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
     "id": "cha-epi-rissschild",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Rissschild",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
     "id": "cha-epi-klammstab",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Klammstab",
     "blurb": "Trägt eine Geschichte, die nicht deine ist",
     "set": "klamm"
@@ -493,7 +493,7 @@
   {
     "id": "cha-epi-klammring",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Klammring",
     "blurb": "Trägt eine Geschichte, die nicht deine ist",
     "set": "klamm"
@@ -501,7 +501,7 @@
   {
     "id": "cha-epi-klammschienen",
     "category": "charakter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Klammschienen",
     "blurb": "Trägt eine Geschichte, die nicht deine ist",
     "set": "klamm"
@@ -509,7 +509,7 @@
   {
     "id": "cha-leg-aschenkrone-der-ersten-nachtwache",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Aschenkrone der ersten Nachtwache",
     "blurb": "Es gibt genau eines davon",
     "set": "nachtwache"
@@ -517,77 +517,77 @@
   {
     "id": "cha-leg-mantel-des-stillen-turms",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Mantel des stillen Turms",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-schritte-des-vierten-stockwerks",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Schritte des vierten Stockwerks",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-gurt-der-geteilten-klamm",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Gurt der geteilten Klamm",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-krone-des-einundvierzigsten-bandes",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Krone des einundvierzigsten Bandes",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-umhang-der-langen-ebbe",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Umhang der langen Ebbe",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-griff-aus-dem-schmelzpunkt",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Griff aus dem Schmelzpunkt",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-scharpe-der-zwolf-fundstucke",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Schärpe der zwölf Fundstücke",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-schild-aus-dem-kiel",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Schild aus dem Kiel",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-stab-der-wetterstange",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Stab der Wetterstange",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-siegel-des-stillen-turms",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Siegel des stillen Turms",
     "blurb": "Es gibt genau eines davon"
   },
   {
     "id": "cha-leg-schienen-vom-grat-im-sturm",
     "category": "charakter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Schienen vom Grat im Sturm",
     "blurb": "Es gibt genau eines davon"
   },
@@ -875,161 +875,161 @@
   {
     "id": "lag-sel-messingkessel",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Messingkessel",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-wollteppich",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wollteppich",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-wetterzelt",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wetterzelt",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-zinnobertopf",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Zinnobertopf",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-schnitzhocker",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Schnitzhocker",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-olplane",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Ölplane",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-steingutkrug",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Steingutkrug",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-schmiededreibein",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Schmiededreibein",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-reisebesen",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Reisebesen",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-wachskerze",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wachskerze",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-zunftbanner",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Zunftbanner",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-lederbalg",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Lederbalg",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-beschlagene-truhe",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Beschlagene Truhe",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-garnwinde",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Garnwinde",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-schmiedehaken",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Schmiedehaken",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-binsenmatte",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Binsenmatte",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-rechenbrett",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Rechenbrett",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-kernseil",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Kernseil",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-messinglaterne",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Messinglaterne",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-sel-wetterfahne",
     "category": "lager",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wetterfahne",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
     "id": "lag-epi-nebelfeuerstelle",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Nebelfeuerstelle",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
     "id": "lag-epi-sternenteppich",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Sternenteppich",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
     "id": "lag-epi-klammzelt",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Klammzelt",
     "blurb": "Wirft Licht, das nicht ganz stimmt",
     "set": "klamm"
@@ -1037,49 +1037,49 @@
   {
     "id": "lag-epi-glutkessel",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Glutkessel",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
     "id": "lag-epi-aschenbanner",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Aschenbanner",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
     "id": "lag-epi-mondsteinlaterne",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Mondsteinlaterne",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
     "id": "lag-epi-rissbeschlag",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Rissbeschlag",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
     "id": "lag-epi-frostkrug",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Frostkrug",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
     "id": "lag-epi-schwingenwimpel",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Schwingenwimpel",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
     "id": "lag-epi-wachfeuerschale",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Wachfeuerschale",
     "blurb": "Wirft Licht, das nicht ganz stimmt",
     "set": "wachfeuer"
@@ -1087,7 +1087,7 @@
   {
     "id": "lag-epi-wachfeuerbock",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Wachfeuerbock",
     "blurb": "Wirft Licht, das nicht ganz stimmt",
     "set": "wachfeuer"
@@ -1095,7 +1095,7 @@
   {
     "id": "lag-epi-wachfeuerkette",
     "category": "lager",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Wachfeuerkette",
     "blurb": "Wirft Licht, das nicht ganz stimmt",
     "set": "wachfeuer"
@@ -1103,63 +1103,63 @@
   {
     "id": "lag-leg-feuerstelle-der-langen-rast",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Feuerstelle der langen Rast",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-banner-der-zwolf-gefahrten",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Banner der zwölf Gefährten",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-zelt-aus-dem-sturmsattel",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Zelt aus dem Sturmsattel",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-kessel-vom-vierten-stockwerk",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Kessel vom vierten Stockwerk",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-laterne-aus-dem-hort",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Laterne aus dem Hort",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-teppich-der-vierzig-turen",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Teppich der vierzig Türen",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-truhe-ohne-boden",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Truhe ohne Boden",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-kette-aus-der-nordwand",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Kette aus der Nordwand",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-schale-der-ersten-nacht",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Schale der ersten Nacht",
     "blurb": "Der Mittelpunkt eines Lagers",
     "set": "nachtwache"
@@ -1167,21 +1167,21 @@
   {
     "id": "lag-leg-bock-aus-dem-kiel",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Bock aus dem Kiel",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-wetterfahne-vom-grat",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Wetterfahne vom Grat",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
     "id": "lag-leg-glocke-ohne-kloppel",
     "category": "lager",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Glocke ohne Klöppel",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
@@ -1468,308 +1468,308 @@
   {
     "id": "beg-sel-rabe",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Rabe",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-fuchs",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Fuchs",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-steinmarder",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Steinmarder",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-uhu",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Uhu",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-wanderfalke",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wanderfalke",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-dachs",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Dachs",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-schneehase",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Schneehase",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-wustenfuchs",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wüstenfuchs",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-fischotter",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Fischotter",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-bergziege",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Bergziege",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-nachtreiher",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Nachtreiher",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-luchskatzchen",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Luchskätzchen",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-wolfswelpe",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wolfswelpe",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-kolkrabe",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Kolkrabe",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-seeadler",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Seeadler",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-waldkauz",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Waldkauz",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-iltis",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Iltis",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-wiesel",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wiesel",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-baummarder",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Baummarder",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-sel-turmfalke",
     "category": "begleiter",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Turmfalke",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
     "id": "beg-epi-nebelrabe",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Nebelrabe",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-glutfuchs",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Glutfuchs",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-frostuhu",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Frostuhu",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-aschenluchs",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Aschenluchs",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-sternenreiher",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Sternenreiher",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-rissmarder",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Rissmarder",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-klammfalke",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Klammfalke",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-mondsteineule",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Mondsteineule",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-schwingenwiesel",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Schwingenwiesel",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-wachfeuerhund",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Wachfeuerhund",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-salzotter",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Salzotter",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-epi-dunenluchs",
     "category": "begleiter",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Dünenluchs",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
     "id": "beg-leg-kleiner-drache",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Kleiner Drache",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-der-einundvierzigste-rabe",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Der einundvierzigste Rabe",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-fuchs-aus-dem-flusterwald",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Fuchs aus dem Flüsterwald",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-warter-der-hohlen-stadt",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Wärter der Hohlen Stadt",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-uhu-vom-grat",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Uhu vom Grat",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-brut-aus-der-nordwand",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Brut aus der Nordwand",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-otter-aus-der-zisterne",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Otter aus der Zisterne",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-falke-der-wetterstange",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Falke der Wetterstange",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-hund-vom-wachfeuer",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Hund vom Wachfeuer",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-katze-aus-kesselgrund",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Katze aus Kesselgrund",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-echse-der-wanderdunen",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Echse der Wanderdünen",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
     "id": "beg-leg-motte-aus-der-schmelze",
     "category": "begleiter",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Motte aus der Schmelze",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
@@ -2056,308 +2056,308 @@
   {
     "id": "atm-sel-glockenboje",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Glockenboje",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-lauten-um-vier",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Läuten um vier",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-die-pendeluhr",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Die Pendeluhr",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-wind-uber-der-klamm",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wind über der Klamm",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-echo-in-der-schlucht",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Echo in der Schlucht",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-regen-im-flusterwald",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Regen im Flüsterwald",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-sand-uber-der-kammlinie",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Sand über der Kammlinie",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-zisternenhall",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Zisternenhall",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-blatter-uber-asche",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Blätter über Asche",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-seile-im-sturm",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Seile im Sturm",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-eis-auf-dem-grat",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Eis auf dem Grat",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-schritte-im-archiv",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Schritte im Archiv",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-turen-in-kesselgrund",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Türen in Kesselgrund",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-feuer-im-wetterzelt",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Feuer im Wetterzelt",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-wasser-unter-dem-damm",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wasser unter dem Damm",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-wind-in-der-kuppel",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Wind in der Kuppel",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-reusen-im-priel",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Reusen im Priel",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-bohlen-im-moor",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Bohlen im Moor",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-staub-in-der-bibliothek",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Staub in der Bibliothek",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-sel-nebel-am-morgen",
     "category": "atmosphaere",
-    "rarity": "selten",
+    "rarity": "ungewoehnlich",
     "name": "Nebel am Morgen",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
     "id": "atm-epi-flugelschlag-uber-der-klamm",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Flügelschlag über der Klamm",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-der-berg-der-sich-teilt",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Der Berg, der sich teilt",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-etwas-atmet-im-hort",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Etwas atmet im Hort",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-nordwand-bei-nacht",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Nordwand bei Nacht",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-was-im-wasser-wartet",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Was im Wasser wartet",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-der-spiegel-wirft-zuruck",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Der Spiegel wirft zurück",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-schmelze-bei-sonnenaufgang",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Schmelze bei Sonnenaufgang",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-sturm-auf-dem-sattel",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Sturm auf dem Sattel",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-das-vierte-stockwerk",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Das vierte Stockwerk",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-regale-die-sich-bewegen",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Regale, die sich bewegen",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-der-kiel-gibt-nach",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Der Kiel gibt nach",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-epi-licht-aus-dem-riss",
     "category": "atmosphaere",
-    "rarity": "episch",
+    "rarity": "selten",
     "name": "Licht aus dem Riss",
     "blurb": "Der Moment vor dem Moment"
   },
   {
     "id": "atm-leg-die-nacht-fur-die-sie-gebaut-wurde",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Die Nacht, für die sie gebaut wurde",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-stille-nach-der-klamm",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Stille nach der Klamm",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-der-einundvierzigste-band",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Der einundvierzigste Band",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-zwolf-fundstucke",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Zwölf Fundstücke",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-das-grune-herz",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Das grüne Herz",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-die-lange-ebbe",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Die lange Ebbe",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-vierzig-blaue-turen",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Vierzig blaue Türen",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-der-schacht-ohne-boden",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Der Schacht ohne Boden",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-was-den-riss-gemacht-hat",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Was den Riss gemacht hat",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-das-feuer-das-hielt",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Das Feuer, das hielt",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-der-weg-hinaus",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Der Weg hinaus",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
     "id": "atm-leg-erste-nachtwache",
     "category": "atmosphaere",
-    "rarity": "legendaer",
+    "rarity": "aussergewoehnlich",
     "name": "Erste Nachtwache",
     "blurb": "Verändert, wie sich das Lager anfühlt",
     "set": "nachtwache"

--- a/content/items.de.json
+++ b/content/items.de.json
@@ -280,210 +280,210 @@
     "blurb": "Abgetragen, aber verlässlich"
   },
   {
-    "id": "cha-sel-zunftmantel",
+    "id": "cha-ung-zunftmantel",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Zunftmantel",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-kettenhaube",
+    "id": "cha-ung-kettenhaube",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Kettenhaube",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-marschstiefel",
+    "id": "cha-ung-marschstiefel",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Marschstiefel",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-silbergurt",
+    "id": "cha-ung-silbergurt",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Silbergurt",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-reiherfeder-kappe",
+    "id": "cha-ung-reiherfeder-kappe",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Reiherfeder-Kappe",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-regenumhang",
+    "id": "cha-ung-regenumhang",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Regenumhang",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-panzerhandschuh",
+    "id": "cha-ung-panzerhandschuh",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Panzerhandschuh",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-leinenscharpe",
+    "id": "cha-ung-leinenscharpe",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Leinenschärpe",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-buckelschild",
+    "id": "cha-ung-buckelschild",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Buckelschild",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-eibenstab",
+    "id": "cha-ung-eibenstab",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Eibenstab",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-silberring",
+    "id": "cha-ung-silberring",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Silberring",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-schienbeinschutz",
+    "id": "cha-ung-schienbeinschutz",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Schienbeinschutz",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-brustharnisch",
+    "id": "cha-ung-brustharnisch",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Brustharnisch",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-kartenrolle",
+    "id": "cha-ung-kartenrolle",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Kartenrolle",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-gurteltasche",
+    "id": "cha-ung-gurteltasche",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Gürteltasche",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-bernsteinamulett",
+    "id": "cha-ung-bernsteinamulett",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Bernsteinamulett",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-zunftklinge",
+    "id": "cha-ung-zunftklinge",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Zunftklinge",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-kapuzenhut",
+    "id": "cha-ung-kapuzenhut",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Kapuzenhut",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-schuppengurt",
+    "id": "cha-ung-schuppengurt",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Schuppengurt",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-sel-armschienen",
+    "id": "cha-ung-armschienen",
     "category": "charakter",
     "rarity": "ungewoehnlich",
     "name": "Armschienen",
     "blurb": "Von jemandem gemacht, der es konnte"
   },
   {
-    "id": "cha-epi-zwielichtmantel",
+    "id": "cha-sel-zwielichtmantel",
     "category": "charakter",
     "rarity": "selten",
     "name": "Zwielichtmantel",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
-    "id": "cha-epi-mondsteinhelm",
+    "id": "cha-sel-mondsteinhelm",
     "category": "charakter",
     "rarity": "selten",
     "name": "Mondsteinhelm",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
-    "id": "cha-epi-nebelganger",
+    "id": "cha-sel-nebelganger",
     "category": "charakter",
     "rarity": "selten",
     "name": "Nebelgänger",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
-    "id": "cha-epi-sternengurt",
+    "id": "cha-sel-sternengurt",
     "category": "charakter",
     "rarity": "selten",
     "name": "Sternengurt",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
-    "id": "cha-epi-schwingenkappe",
+    "id": "cha-sel-schwingenkappe",
     "category": "charakter",
     "rarity": "selten",
     "name": "Schwingenkappe",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
-    "id": "cha-epi-aschenumhang",
+    "id": "cha-sel-aschenumhang",
     "category": "charakter",
     "rarity": "selten",
     "name": "Aschenumhang",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
-    "id": "cha-epi-frostgriff",
+    "id": "cha-sel-frostgriff",
     "category": "charakter",
     "rarity": "selten",
     "name": "Frostgriff",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
-    "id": "cha-epi-glutscharpe",
+    "id": "cha-sel-glutscharpe",
     "category": "charakter",
     "rarity": "selten",
     "name": "Glutschärpe",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
-    "id": "cha-epi-rissschild",
+    "id": "cha-sel-rissschild",
     "category": "charakter",
     "rarity": "selten",
     "name": "Rissschild",
     "blurb": "Trägt eine Geschichte, die nicht deine ist"
   },
   {
-    "id": "cha-epi-klammstab",
+    "id": "cha-sel-klammstab",
     "category": "charakter",
     "rarity": "selten",
     "name": "Klammstab",
@@ -491,7 +491,7 @@
     "set": "klamm"
   },
   {
-    "id": "cha-epi-klammring",
+    "id": "cha-sel-klammring",
     "category": "charakter",
     "rarity": "selten",
     "name": "Klammring",
@@ -499,7 +499,7 @@
     "set": "klamm"
   },
   {
-    "id": "cha-epi-klammschienen",
+    "id": "cha-sel-klammschienen",
     "category": "charakter",
     "rarity": "selten",
     "name": "Klammschienen",
@@ -507,7 +507,7 @@
     "set": "klamm"
   },
   {
-    "id": "cha-leg-aschenkrone-der-ersten-nachtwache",
+    "id": "cha-aus-aschenkrone-der-ersten-nachtwache",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Aschenkrone der ersten Nachtwache",
@@ -515,77 +515,77 @@
     "set": "nachtwache"
   },
   {
-    "id": "cha-leg-mantel-des-stillen-turms",
+    "id": "cha-aus-mantel-des-stillen-turms",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Mantel des stillen Turms",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-schritte-des-vierten-stockwerks",
+    "id": "cha-aus-schritte-des-vierten-stockwerks",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Schritte des vierten Stockwerks",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-gurt-der-geteilten-klamm",
+    "id": "cha-aus-gurt-der-geteilten-klamm",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Gurt der geteilten Klamm",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-krone-des-einundvierzigsten-bandes",
+    "id": "cha-aus-krone-des-einundvierzigsten-bandes",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Krone des einundvierzigsten Bandes",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-umhang-der-langen-ebbe",
+    "id": "cha-aus-umhang-der-langen-ebbe",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Umhang der langen Ebbe",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-griff-aus-dem-schmelzpunkt",
+    "id": "cha-aus-griff-aus-dem-schmelzpunkt",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Griff aus dem Schmelzpunkt",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-scharpe-der-zwolf-fundstucke",
+    "id": "cha-aus-scharpe-der-zwolf-fundstucke",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Schärpe der zwölf Fundstücke",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-schild-aus-dem-kiel",
+    "id": "cha-aus-schild-aus-dem-kiel",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Schild aus dem Kiel",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-stab-der-wetterstange",
+    "id": "cha-aus-stab-der-wetterstange",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Stab der Wetterstange",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-siegel-des-stillen-turms",
+    "id": "cha-aus-siegel-des-stillen-turms",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Siegel des stillen Turms",
     "blurb": "Es gibt genau eines davon"
   },
   {
-    "id": "cha-leg-schienen-vom-grat-im-sturm",
+    "id": "cha-aus-schienen-vom-grat-im-sturm",
     "category": "charakter",
     "rarity": "aussergewoehnlich",
     "name": "Schienen vom Grat im Sturm",
@@ -873,161 +873,161 @@
     "blurb": "Steht da und tut, was es soll"
   },
   {
-    "id": "lag-sel-messingkessel",
+    "id": "lag-ung-messingkessel",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Messingkessel",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-wollteppich",
+    "id": "lag-ung-wollteppich",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Wollteppich",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-wetterzelt",
+    "id": "lag-ung-wetterzelt",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Wetterzelt",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-zinnobertopf",
+    "id": "lag-ung-zinnobertopf",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Zinnobertopf",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-schnitzhocker",
+    "id": "lag-ung-schnitzhocker",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Schnitzhocker",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-olplane",
+    "id": "lag-ung-olplane",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Ölplane",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-steingutkrug",
+    "id": "lag-ung-steingutkrug",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Steingutkrug",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-schmiededreibein",
+    "id": "lag-ung-schmiededreibein",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Schmiededreibein",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-reisebesen",
+    "id": "lag-ung-reisebesen",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Reisebesen",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-wachskerze",
+    "id": "lag-ung-wachskerze",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Wachskerze",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-zunftbanner",
+    "id": "lag-ung-zunftbanner",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Zunftbanner",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-lederbalg",
+    "id": "lag-ung-lederbalg",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Lederbalg",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-beschlagene-truhe",
+    "id": "lag-ung-beschlagene-truhe",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Beschlagene Truhe",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-garnwinde",
+    "id": "lag-ung-garnwinde",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Garnwinde",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-schmiedehaken",
+    "id": "lag-ung-schmiedehaken",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Schmiedehaken",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-binsenmatte",
+    "id": "lag-ung-binsenmatte",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Binsenmatte",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-rechenbrett",
+    "id": "lag-ung-rechenbrett",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Rechenbrett",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-kernseil",
+    "id": "lag-ung-kernseil",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Kernseil",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-messinglaterne",
+    "id": "lag-ung-messinglaterne",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Messinglaterne",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-sel-wetterfahne",
+    "id": "lag-ung-wetterfahne",
     "category": "lager",
     "rarity": "ungewoehnlich",
     "name": "Wetterfahne",
     "blurb": "Jemand hat sich Mühe gegeben"
   },
   {
-    "id": "lag-epi-nebelfeuerstelle",
+    "id": "lag-sel-nebelfeuerstelle",
     "category": "lager",
     "rarity": "selten",
     "name": "Nebelfeuerstelle",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
-    "id": "lag-epi-sternenteppich",
+    "id": "lag-sel-sternenteppich",
     "category": "lager",
     "rarity": "selten",
     "name": "Sternenteppich",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
-    "id": "lag-epi-klammzelt",
+    "id": "lag-sel-klammzelt",
     "category": "lager",
     "rarity": "selten",
     "name": "Klammzelt",
@@ -1035,49 +1035,49 @@
     "set": "klamm"
   },
   {
-    "id": "lag-epi-glutkessel",
+    "id": "lag-sel-glutkessel",
     "category": "lager",
     "rarity": "selten",
     "name": "Glutkessel",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
-    "id": "lag-epi-aschenbanner",
+    "id": "lag-sel-aschenbanner",
     "category": "lager",
     "rarity": "selten",
     "name": "Aschenbanner",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
-    "id": "lag-epi-mondsteinlaterne",
+    "id": "lag-sel-mondsteinlaterne",
     "category": "lager",
     "rarity": "selten",
     "name": "Mondsteinlaterne",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
-    "id": "lag-epi-rissbeschlag",
+    "id": "lag-sel-rissbeschlag",
     "category": "lager",
     "rarity": "selten",
     "name": "Rissbeschlag",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
-    "id": "lag-epi-frostkrug",
+    "id": "lag-sel-frostkrug",
     "category": "lager",
     "rarity": "selten",
     "name": "Frostkrug",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
-    "id": "lag-epi-schwingenwimpel",
+    "id": "lag-sel-schwingenwimpel",
     "category": "lager",
     "rarity": "selten",
     "name": "Schwingenwimpel",
     "blurb": "Wirft Licht, das nicht ganz stimmt"
   },
   {
-    "id": "lag-epi-wachfeuerschale",
+    "id": "lag-sel-wachfeuerschale",
     "category": "lager",
     "rarity": "selten",
     "name": "Wachfeuerschale",
@@ -1085,7 +1085,7 @@
     "set": "wachfeuer"
   },
   {
-    "id": "lag-epi-wachfeuerbock",
+    "id": "lag-sel-wachfeuerbock",
     "category": "lager",
     "rarity": "selten",
     "name": "Wachfeuerbock",
@@ -1093,7 +1093,7 @@
     "set": "wachfeuer"
   },
   {
-    "id": "lag-epi-wachfeuerkette",
+    "id": "lag-sel-wachfeuerkette",
     "category": "lager",
     "rarity": "selten",
     "name": "Wachfeuerkette",
@@ -1101,63 +1101,63 @@
     "set": "wachfeuer"
   },
   {
-    "id": "lag-leg-feuerstelle-der-langen-rast",
+    "id": "lag-aus-feuerstelle-der-langen-rast",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Feuerstelle der langen Rast",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-banner-der-zwolf-gefahrten",
+    "id": "lag-aus-banner-der-zwolf-gefahrten",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Banner der zwölf Gefährten",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-zelt-aus-dem-sturmsattel",
+    "id": "lag-aus-zelt-aus-dem-sturmsattel",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Zelt aus dem Sturmsattel",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-kessel-vom-vierten-stockwerk",
+    "id": "lag-aus-kessel-vom-vierten-stockwerk",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Kessel vom vierten Stockwerk",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-laterne-aus-dem-hort",
+    "id": "lag-aus-laterne-aus-dem-hort",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Laterne aus dem Hort",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-teppich-der-vierzig-turen",
+    "id": "lag-aus-teppich-der-vierzig-turen",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Teppich der vierzig Türen",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-truhe-ohne-boden",
+    "id": "lag-aus-truhe-ohne-boden",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Truhe ohne Boden",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-kette-aus-der-nordwand",
+    "id": "lag-aus-kette-aus-der-nordwand",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Kette aus der Nordwand",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-schale-der-ersten-nacht",
+    "id": "lag-aus-schale-der-ersten-nacht",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Schale der ersten Nacht",
@@ -1165,21 +1165,21 @@
     "set": "nachtwache"
   },
   {
-    "id": "lag-leg-bock-aus-dem-kiel",
+    "id": "lag-aus-bock-aus-dem-kiel",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Bock aus dem Kiel",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-wetterfahne-vom-grat",
+    "id": "lag-aus-wetterfahne-vom-grat",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Wetterfahne vom Grat",
     "blurb": "Der Mittelpunkt eines Lagers"
   },
   {
-    "id": "lag-leg-glocke-ohne-kloppel",
+    "id": "lag-aus-glocke-ohne-kloppel",
     "category": "lager",
     "rarity": "aussergewoehnlich",
     "name": "Glocke ohne Klöppel",
@@ -1466,308 +1466,308 @@
     "blurb": "Kleiner Begleiter, große Ausdauer"
   },
   {
-    "id": "beg-sel-rabe",
+    "id": "beg-ung-rabe",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Rabe",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-fuchs",
+    "id": "beg-ung-fuchs",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Fuchs",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-steinmarder",
+    "id": "beg-ung-steinmarder",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Steinmarder",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-uhu",
+    "id": "beg-ung-uhu",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Uhu",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-wanderfalke",
+    "id": "beg-ung-wanderfalke",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Wanderfalke",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-dachs",
+    "id": "beg-ung-dachs",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Dachs",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-schneehase",
+    "id": "beg-ung-schneehase",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Schneehase",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-wustenfuchs",
+    "id": "beg-ung-wustenfuchs",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Wüstenfuchs",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-fischotter",
+    "id": "beg-ung-fischotter",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Fischotter",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-bergziege",
+    "id": "beg-ung-bergziege",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Bergziege",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-nachtreiher",
+    "id": "beg-ung-nachtreiher",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Nachtreiher",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-luchskatzchen",
+    "id": "beg-ung-luchskatzchen",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Luchskätzchen",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-wolfswelpe",
+    "id": "beg-ung-wolfswelpe",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Wolfswelpe",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-kolkrabe",
+    "id": "beg-ung-kolkrabe",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Kolkrabe",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-seeadler",
+    "id": "beg-ung-seeadler",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Seeadler",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-waldkauz",
+    "id": "beg-ung-waldkauz",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Waldkauz",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-iltis",
+    "id": "beg-ung-iltis",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Iltis",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-wiesel",
+    "id": "beg-ung-wiesel",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Wiesel",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-baummarder",
+    "id": "beg-ung-baummarder",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Baummarder",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-sel-turmfalke",
+    "id": "beg-ung-turmfalke",
     "category": "begleiter",
     "rarity": "ungewoehnlich",
     "name": "Turmfalke",
     "blurb": "Kommt wieder, wenn du ihn lässt"
   },
   {
-    "id": "beg-epi-nebelrabe",
+    "id": "beg-sel-nebelrabe",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Nebelrabe",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-glutfuchs",
+    "id": "beg-sel-glutfuchs",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Glutfuchs",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-frostuhu",
+    "id": "beg-sel-frostuhu",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Frostuhu",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-aschenluchs",
+    "id": "beg-sel-aschenluchs",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Aschenluchs",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-sternenreiher",
+    "id": "beg-sel-sternenreiher",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Sternenreiher",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-rissmarder",
+    "id": "beg-sel-rissmarder",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Rissmarder",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-klammfalke",
+    "id": "beg-sel-klammfalke",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Klammfalke",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-mondsteineule",
+    "id": "beg-sel-mondsteineule",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Mondsteineule",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-schwingenwiesel",
+    "id": "beg-sel-schwingenwiesel",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Schwingenwiesel",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-wachfeuerhund",
+    "id": "beg-sel-wachfeuerhund",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Wachfeuerhund",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-salzotter",
+    "id": "beg-sel-salzotter",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Salzotter",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-epi-dunenluchs",
+    "id": "beg-sel-dunenluchs",
     "category": "begleiter",
     "rarity": "selten",
     "name": "Dünenluchs",
     "blurb": "Sieht Dinge, bevor du sie siehst"
   },
   {
-    "id": "beg-leg-kleiner-drache",
+    "id": "beg-aus-kleiner-drache",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Kleiner Drache",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-der-einundvierzigste-rabe",
+    "id": "beg-aus-der-einundvierzigste-rabe",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Der einundvierzigste Rabe",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-fuchs-aus-dem-flusterwald",
+    "id": "beg-aus-fuchs-aus-dem-flusterwald",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Fuchs aus dem Flüsterwald",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-warter-der-hohlen-stadt",
+    "id": "beg-aus-warter-der-hohlen-stadt",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Wärter der Hohlen Stadt",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-uhu-vom-grat",
+    "id": "beg-aus-uhu-vom-grat",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Uhu vom Grat",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-brut-aus-der-nordwand",
+    "id": "beg-aus-brut-aus-der-nordwand",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Brut aus der Nordwand",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-otter-aus-der-zisterne",
+    "id": "beg-aus-otter-aus-der-zisterne",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Otter aus der Zisterne",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-falke-der-wetterstange",
+    "id": "beg-aus-falke-der-wetterstange",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Falke der Wetterstange",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-hund-vom-wachfeuer",
+    "id": "beg-aus-hund-vom-wachfeuer",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Hund vom Wachfeuer",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-katze-aus-kesselgrund",
+    "id": "beg-aus-katze-aus-kesselgrund",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Katze aus Kesselgrund",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-echse-der-wanderdunen",
+    "id": "beg-aus-echse-der-wanderdunen",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Echse der Wanderdünen",
     "blurb": "Es hat sich entschieden, dir zu folgen"
   },
   {
-    "id": "beg-leg-motte-aus-der-schmelze",
+    "id": "beg-aus-motte-aus-der-schmelze",
     "category": "begleiter",
     "rarity": "aussergewoehnlich",
     "name": "Motte aus der Schmelze",
@@ -2054,308 +2054,308 @@
     "blurb": "Ein Ton für den Hintergrund"
   },
   {
-    "id": "atm-sel-glockenboje",
+    "id": "atm-ung-glockenboje",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Glockenboje",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-lauten-um-vier",
+    "id": "atm-ung-lauten-um-vier",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Läuten um vier",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-die-pendeluhr",
+    "id": "atm-ung-die-pendeluhr",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Die Pendeluhr",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-wind-uber-der-klamm",
+    "id": "atm-ung-wind-uber-der-klamm",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Wind über der Klamm",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-echo-in-der-schlucht",
+    "id": "atm-ung-echo-in-der-schlucht",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Echo in der Schlucht",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-regen-im-flusterwald",
+    "id": "atm-ung-regen-im-flusterwald",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Regen im Flüsterwald",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-sand-uber-der-kammlinie",
+    "id": "atm-ung-sand-uber-der-kammlinie",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Sand über der Kammlinie",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-zisternenhall",
+    "id": "atm-ung-zisternenhall",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Zisternenhall",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-blatter-uber-asche",
+    "id": "atm-ung-blatter-uber-asche",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Blätter über Asche",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-seile-im-sturm",
+    "id": "atm-ung-seile-im-sturm",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Seile im Sturm",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-eis-auf-dem-grat",
+    "id": "atm-ung-eis-auf-dem-grat",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Eis auf dem Grat",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-schritte-im-archiv",
+    "id": "atm-ung-schritte-im-archiv",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Schritte im Archiv",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-turen-in-kesselgrund",
+    "id": "atm-ung-turen-in-kesselgrund",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Türen in Kesselgrund",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-feuer-im-wetterzelt",
+    "id": "atm-ung-feuer-im-wetterzelt",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Feuer im Wetterzelt",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-wasser-unter-dem-damm",
+    "id": "atm-ung-wasser-unter-dem-damm",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Wasser unter dem Damm",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-wind-in-der-kuppel",
+    "id": "atm-ung-wind-in-der-kuppel",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Wind in der Kuppel",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-reusen-im-priel",
+    "id": "atm-ung-reusen-im-priel",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Reusen im Priel",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-bohlen-im-moor",
+    "id": "atm-ung-bohlen-im-moor",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Bohlen im Moor",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-staub-in-der-bibliothek",
+    "id": "atm-ung-staub-in-der-bibliothek",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Staub in der Bibliothek",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-sel-nebel-am-morgen",
+    "id": "atm-ung-nebel-am-morgen",
     "category": "atmosphaere",
     "rarity": "ungewoehnlich",
     "name": "Nebel am Morgen",
     "blurb": "Man weiß sofort, wo man ist"
   },
   {
-    "id": "atm-epi-flugelschlag-uber-der-klamm",
+    "id": "atm-sel-flugelschlag-uber-der-klamm",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Flügelschlag über der Klamm",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-der-berg-der-sich-teilt",
+    "id": "atm-sel-der-berg-der-sich-teilt",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Der Berg, der sich teilt",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-etwas-atmet-im-hort",
+    "id": "atm-sel-etwas-atmet-im-hort",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Etwas atmet im Hort",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-nordwand-bei-nacht",
+    "id": "atm-sel-nordwand-bei-nacht",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Nordwand bei Nacht",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-was-im-wasser-wartet",
+    "id": "atm-sel-was-im-wasser-wartet",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Was im Wasser wartet",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-der-spiegel-wirft-zuruck",
+    "id": "atm-sel-der-spiegel-wirft-zuruck",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Der Spiegel wirft zurück",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-schmelze-bei-sonnenaufgang",
+    "id": "atm-sel-schmelze-bei-sonnenaufgang",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Schmelze bei Sonnenaufgang",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-sturm-auf-dem-sattel",
+    "id": "atm-sel-sturm-auf-dem-sattel",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Sturm auf dem Sattel",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-das-vierte-stockwerk",
+    "id": "atm-sel-das-vierte-stockwerk",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Das vierte Stockwerk",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-regale-die-sich-bewegen",
+    "id": "atm-sel-regale-die-sich-bewegen",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Regale, die sich bewegen",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-der-kiel-gibt-nach",
+    "id": "atm-sel-der-kiel-gibt-nach",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Der Kiel gibt nach",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-epi-licht-aus-dem-riss",
+    "id": "atm-sel-licht-aus-dem-riss",
     "category": "atmosphaere",
     "rarity": "selten",
     "name": "Licht aus dem Riss",
     "blurb": "Der Moment vor dem Moment"
   },
   {
-    "id": "atm-leg-die-nacht-fur-die-sie-gebaut-wurde",
+    "id": "atm-aus-die-nacht-fur-die-sie-gebaut-wurde",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Die Nacht, für die sie gebaut wurde",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-stille-nach-der-klamm",
+    "id": "atm-aus-stille-nach-der-klamm",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Stille nach der Klamm",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-der-einundvierzigste-band",
+    "id": "atm-aus-der-einundvierzigste-band",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Der einundvierzigste Band",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-zwolf-fundstucke",
+    "id": "atm-aus-zwolf-fundstucke",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Zwölf Fundstücke",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-das-grune-herz",
+    "id": "atm-aus-das-grune-herz",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Das grüne Herz",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-die-lange-ebbe",
+    "id": "atm-aus-die-lange-ebbe",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Die lange Ebbe",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-vierzig-blaue-turen",
+    "id": "atm-aus-vierzig-blaue-turen",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Vierzig blaue Türen",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-der-schacht-ohne-boden",
+    "id": "atm-aus-der-schacht-ohne-boden",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Der Schacht ohne Boden",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-was-den-riss-gemacht-hat",
+    "id": "atm-aus-was-den-riss-gemacht-hat",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Was den Riss gemacht hat",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-das-feuer-das-hielt",
+    "id": "atm-aus-das-feuer-das-hielt",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Das Feuer, das hielt",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-der-weg-hinaus",
+    "id": "atm-aus-der-weg-hinaus",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Der Weg hinaus",
     "blurb": "Verändert, wie sich das Lager anfühlt"
   },
   {
-    "id": "atm-leg-erste-nachtwache",
+    "id": "atm-aus-erste-nachtwache",
     "category": "atmosphaere",
     "rarity": "aussergewoehnlich",
     "name": "Erste Nachtwache",

--- a/lib/loot/__tests__/catalogue.test.ts
+++ b/lib/loot/__tests__/catalogue.test.ts
@@ -88,7 +88,7 @@ describe('Reichweite unter echter Nutzung', () => {
         }
       }
     }
-    // Kein einziges Duplikat in 240 Truhen — das ist die Regel aus Konzept V1 §10.
+    // Kein einziges Duplikat in 240 Truhen — das ist die Regel aus docs/CONCEPT.md §4.
     expect(goldStattItem).toBe(0)
     expect(owned.size).toBe(240)
   })

--- a/lib/loot/__tests__/draw.test.ts
+++ b/lib/loot/__tests__/draw.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   MIN_POOL_SIZE, RARITIES, RARITY_CHANCE,
-  drawLoot, drawsRemaining, setCompletedBy,
+  drawLoot, drawsRemaining, rollRarity, setCompletedBy,
   type CatalogueItem, type Category, type Rarity,
 } from '../draw'
 
@@ -11,17 +11,17 @@ const cat = (
 
 const catalogue: CatalogueItem[] = [
   ...Array.from({ length: 5 }, (_, i) => cat(`c-gew-${i}`, 'charakter', 'gewoehnlich')),
-  ...Array.from({ length: 3 }, (_, i) => cat(`c-sel-${i}`, 'charakter', 'selten')),
-  ...Array.from({ length: 2 }, (_, i) => cat(`c-epi-${i}`, 'charakter', 'episch')),
-  cat('c-leg-0', 'charakter', 'legendaer'),
+  ...Array.from({ length: 3 }, (_, i) => cat(`c-ung-${i}`, 'charakter', 'ungewoehnlich')),
+  ...Array.from({ length: 2 }, (_, i) => cat(`c-sel-${i}`, 'charakter', 'selten')),
+  cat('c-aus-0', 'charakter', 'aussergewoehnlich'),
   ...Array.from({ length: 4 }, (_, i) => cat(`l-gew-${i}`, 'lager', 'gewoehnlich')),
-  cat('set-a', 'lager', 'selten', 'wachfeuer'),
-  cat('set-b', 'lager', 'selten', 'wachfeuer'),
-  cat('set-c', 'lager', 'selten', 'wachfeuer'),
+  cat('set-a', 'lager', 'ungewoehnlich', 'wachfeuer'),
+  cat('set-b', 'lager', 'ungewoehnlich', 'wachfeuer'),
+  cat('set-c', 'lager', 'ungewoehnlich', 'wachfeuer'),
 ]
 
 describe('Seltenheiten', () => {
-  it('hat vier Stufen nach Konzept V1 §10', () => {
+  it('hat vier Stufen nach ADR-021', () => {
     expect(RARITIES).toHaveLength(4)
   })
 
@@ -33,6 +33,47 @@ describe('Seltenheiten', () => {
   it('macht seltenere Stufen auch seltener', () => {
     for (let i = 1; i < RARITIES.length; i++) {
       expect(RARITY_CHANCE[RARITIES[i]!]).toBeLessThan(RARITY_CHANCE[RARITIES[i - 1]!])
+    }
+  })
+
+  it('trägt die Stufennamen aus ADR-021, nicht die alten V1-Namen', () => {
+    expect(RARITIES).toEqual(['gewoehnlich', 'ungewoehnlich', 'selten', 'aussergewoehnlich'])
+    expect(RARITIES).not.toContain('episch')
+    expect(RARITIES).not.toContain('legendaer')
+  })
+})
+
+describe('rollRarity — gewichtete Ziehung der Seltenheitsstufe', () => {
+  it('ist deterministisch: derselbe Seed ergibt immer dieselbe Stufe', () => {
+    expect(rollRarity('immer-gleich')).toBe(rollRarity('immer-gleich'))
+  })
+
+  it('liefert nur bekannte Stufen', () => {
+    for (let i = 0; i < 500; i++) {
+      expect(RARITIES).toContain(rollRarity(`bekannt-${i}`))
+    }
+  })
+
+  it('trifft bei genug verschiedenen Seeds jede der vier Stufen', () => {
+    const seen = new Set<Rarity>()
+    for (let i = 0; i < 3000; i++) seen.add(rollRarity(`seed-${i}`))
+    expect(seen.size).toBe(RARITIES.length)
+  })
+
+  it('verteilt sich über 20.000 Seeds auf ±2 Prozentpunkte genau nach RARITY_CHANCE', () => {
+    const n = 20_000
+    const counts: Record<Rarity, number> = {
+      gewoehnlich: 0, ungewoehnlich: 0, selten: 0, aussergewoehnlich: 0,
+    }
+    for (let i = 0; i < n; i++) counts[rollRarity(`verteilung-${i}`)]++
+
+    const toleranz = 0.02 // ±2 Prozentpunkte
+    for (const r of RARITIES) {
+      const empirisch = counts[r] / n
+      expect(empirisch, `Stufe ${r}: ${counts[r]} von ${n}`)
+        .toBeGreaterThan(RARITY_CHANCE[r] - toleranz)
+      expect(empirisch, `Stufe ${r}: ${counts[r]} von ${n}`)
+        .toBeLessThan(RARITY_CHANCE[r] + toleranz)
     }
   })
 })
@@ -60,25 +101,28 @@ describe('drawLoot — die zentrale Regel: keine Duplikate', () => {
   })
 
   it('weicht bei leerem Topf nach unten aus, nicht nach oben', () => {
-    // Beide epischen Charakter-Gegenstände sind weg.
-    const owned = new Set(['c-epi-0', 'c-epi-1'])
-    const d = drawLoot(catalogue, owned, 'episch', 'charakter', 'seed')
+    // Beide seltenen Charakter-Gegenstände sind weg.
+    const owned = new Set(['c-sel-0', 'c-sel-1'])
+    const d = drawLoot(catalogue, owned, 'selten', 'charakter', 'seed')
     expect(d.item).not.toBeNull()
-    expect(d.item!.rarity).toBe('selten')
-    expect(d.item!.rarity).not.toBe('legendaer')
+    expect(d.item!.rarity).toBe('ungewoehnlich')
+    expect(d.item!.rarity).not.toBe('aussergewoehnlich')
   })
 
   it('gibt Gold statt eines Duplikats, wenn alles leer ist', () => {
     const owned = new Set(catalogue.map((c) => c.id))
-    const d = drawLoot(catalogue, owned, 'legendaer', 'charakter', 'seed')
+    const d = drawLoot(catalogue, owned, 'aussergewoehnlich', 'charakter', 'seed')
     expect(d.item).toBeNull()
     expect(d.goldInstead).toBeGreaterThan(0)
   })
 
-  it('gibt allen Party-Mitgliedern dieselbe Party-Truhe', () => {
+  it('ist deterministisch: derselbe Seed ergibt immer denselben Gegenstand', () => {
+    // Keine Party-Truhe (ADR-025) — jede Person zieht individuell. Das hier prüft
+    // nur, dass drawLoot eine reine Funktion ist: wichtig für eine serverseitig
+    // nachvollziehbare Ziehung und für Tests, nicht für geteilten Loot.
     const owned = new Set<string>()
-    const a = drawLoot(catalogue, owned, 'selten', 'charakter', 'H26HE:2026-09-04T10:00Z')
-    const b = drawLoot(catalogue, owned, 'selten', 'charakter', 'H26HE:2026-09-04T10:00Z')
+    const a = drawLoot(catalogue, owned, 'ungewoehnlich', 'charakter', 'session-42')
+    const b = drawLoot(catalogue, owned, 'ungewoehnlich', 'charakter', 'session-42')
     expect(a.item?.id).toBe(b.item?.id)
   })
 
@@ -111,7 +155,7 @@ describe('Sammlungssets', () => {
 
   it('meldet die Vervollständigung auch aus einer echten Ziehung heraus', () => {
     const owned = new Set(['set-a', 'set-b'])
-    const d = drawLoot(catalogue, owned, 'selten', 'lager', 'seed')
+    const d = drawLoot(catalogue, owned, 'ungewoehnlich', 'lager', 'seed')
     expect(d.item?.id).toBe('set-c')
     expect(d.completedSet).toBe('wachfeuer')
   })
@@ -124,8 +168,9 @@ describe('Reichweite der Töpfe', () => {
   })
 
   it('benennt Mindestgrößen für alle vier Stufen', () => {
-    // Konzept V1 verlangt „keine Duplikate", sagt aber nicht, wie groß die Töpfe
-    // sein müssen. Ohne diese Zahlen greift die Regel nach zwei Wochen ins Leere.
+    // Concept V2 verlangt „keine Duplikate" (docs/CONCEPT.md §4), sagt aber nicht,
+    // wie groß die Töpfe sein müssen. Ohne diese Zahlen greift die Regel nach zwei
+    // Wochen ins Leere.
     for (const r of RARITIES) expect(MIN_POOL_SIZE[r]).toBeGreaterThanOrEqual(12)
   })
 

--- a/lib/loot/__tests__/rewards.test.ts
+++ b/lib/loot/__tests__/rewards.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Deckt die im Issue #15 genannten Fälle exakt ab: 15/25/50-Minuten-Quests
+ * ergeben 3/5/10 Gold, XP ist 1:1 zu den tatsächlich fokussierten Minuten.
+ */
+import { describe, expect, it } from 'vitest'
+import { questCompletionGold, questCompletionXp } from '../rewards'
+
+describe('questCompletionXp', () => {
+  it('gibt 1 XP pro tatsächlich fokussierter Minute', () => {
+    expect(questCompletionXp(15)).toBe(15)
+    expect(questCompletionXp(25)).toBe(25)
+    expect(questCompletionXp(50)).toBe(50)
+    expect(questCompletionXp(1)).toBe(1)
+  })
+
+  it('kennt keine Boni oder Multiplikatoren', () => {
+    // Keine Klassen-Passive, keine XP-Multiplikatoren (#15) — die Formel ist
+    // strikt linear, unabhängig von Länge oder Häufigkeit.
+    expect(questCompletionXp(10)).toBe(10)
+    expect(questCompletionXp(100)).toBe(100)
+  })
+
+  it('gibt bei nicht-positiven Minuten 0 XP', () => {
+    expect(questCompletionXp(0)).toBe(0)
+    expect(questCompletionXp(-5)).toBe(0)
+  })
+})
+
+describe('questCompletionGold', () => {
+  it('ergibt für 15/25/50-Minuten-Quests 3/5/10 Gold — die Fälle aus #15', () => {
+    expect(questCompletionGold(15)).toBe(3)
+    expect(questCompletionGold(25)).toBe(5)
+    expect(questCompletionGold(50)).toBe(10)
+  })
+
+  it('rundet ab, statt aufzurunden', () => {
+    // 1 Gold pro 5 erfolgreich abgeschlossenen Fokusminuten (ADR-030) — angebrochene
+    // Fünf-Minuten-Blöcke geben kein anteiliges Gold.
+    expect(questCompletionGold(19)).toBe(3)
+    expect(questCompletionGold(4)).toBe(0)
+  })
+
+  it('gibt bei nicht-positiver Dauer 0 Gold', () => {
+    expect(questCompletionGold(0)).toBe(0)
+    expect(questCompletionGold(-10)).toBe(0)
+  })
+})

--- a/lib/loot/draw.ts
+++ b/lib/loot/draw.ts
@@ -1,34 +1,35 @@
 /**
- * Truhenziehung nach der zentralen Loot-Regel aus Konzept V1 §10:
+ * Truhenziehung nach der zentralen Loot-Regel aus Concept V2, docs/CONCEPT.md §4:
  *
- *   „Keine Duplikate. Eine Truhe enthält grundsätzlich etwas Neues,
- *    solange innerhalb des jeweiligen Pools noch etwas Neues verfügbar ist."
+ *   „Wenn eine Truhe ein Item enthält, ist es neu. Keine Duplikate."
  *
  * Das ist der Grund, warum Gegenstände nicht mehr aus einer Kennung errechnet
  * werden können (so machte es lib/loot/items.ts): Gezogen wird aus einem Katalog,
  * und zwar aus dem, was noch nicht besessen wird. Der Baukasten aus items.ts
  * bleibt — er liefert jetzt das Aussehen eines Katalogeintrags ohne Illustration.
  *
- * Siehe docs/KONZEPT-ABGLEICH.md, K6.
- *
  * Rein: keine React-Importe, kein Math.random(), keine Uhr. Die Ziehung ist
- * deterministisch aus einem Seed — damit sehen alle Party-Mitglieder dieselbe
- * Party-Truhe, ohne dass sie jemand verteilen muss.
+ * deterministisch aus einem Seed — dieselbe Eingabe ergibt reproduzierbar dasselbe
+ * Ergebnis, was eine serverseitige Ziehung testbar und nachvollziehbar macht. Das
+ * ist unabhängig von Party-Fragen: Nach ADR-025 gibt es keine Party-Truhe, jede
+ * Person erhält eine eigene, individuelle Ziehung.
  */
 
 export type Category = 'charakter' | 'lager' | 'begleiter' | 'atmosphaere'
 
-/** Vier Stufen nach Konzept V1 §10 — siehe K7 im Abgleich. */
-export type Rarity = 'gewoehnlich' | 'selten' | 'episch' | 'legendaer'
+/** Vier Stufen nach Concept V2, ADR-021. */
+export type Rarity = 'gewoehnlich' | 'ungewoehnlich' | 'selten' | 'aussergewoehnlich'
 
-export const RARITIES: readonly Rarity[] = ['gewoehnlich', 'selten', 'episch', 'legendaer']
+export const RARITIES: readonly Rarity[] = [
+  'gewoehnlich', 'ungewoehnlich', 'selten', 'aussergewoehnlich',
+]
 
-/** Summiert sich auf 1. Angepasst von fünf auf vier Stufen. */
+/** Summiert sich auf 1. Werte nach ADR-021: 60 / 27 / 11 / 2 %. */
 export const RARITY_CHANCE: Record<Rarity, number> = {
   gewoehnlich: 0.6,
-  selten: 0.27,
-  episch: 0.11,
-  legendaer: 0.02,
+  ungewoehnlich: 0.27,
+  selten: 0.11,
+  aussergewoehnlich: 0.02,
 }
 
 export interface CatalogueItem {
@@ -46,7 +47,8 @@ export interface CatalogueItem {
  * Was eine Truhe hergibt.
  *
  * `item: null` heißt: Der Topf ist leer. Dann gibt es Gold statt eines Gegenstands —
- * niemals ein Duplikat. Das ist der Fall, den Konzept V1 offenlässt (W4 im Abgleich).
+ * niemals ein Duplikat. Dieser Fall ist in docs/CONCEPT.md nicht spezifiziert; die
+ * Herleitung der Ersatzregel steht in docs/KONZEPT-ABGLEICH.md, W4.
  */
 export interface Drop {
   item: CatalogueItem | null
@@ -66,11 +68,34 @@ function hash(seed: string): number {
 }
 
 /**
+ * Würfelt deterministisch aus einem Seed eine Seltenheitsstufe, gewichtet nach
+ * RARITY_CHANCE (ADR-021: 60 / 27 / 11 / 2 %).
+ *
+ * Wie `hash()` selbst: kein `Math.random()`, derselbe Seed ergibt immer dieselbe
+ * Stufe. Das macht die Ziehung serverseitig nachvollziehbar und die Verteilung
+ * automatisiert testbar (Akzeptanzkriterium aus #15) — mit `Math.random()` ließe
+ * sich zwar auch eine korrekte Verteilung erzeugen, aber kein einzelnes Ergebnis
+ * im Nachhinein reproduzieren oder in einem Test gezielt herbeiführen.
+ */
+export function rollRarity(seed: string): Rarity {
+  // hash() liefert einen vollen 32-Bit-Wert; Teilen durch 2^32 ergibt eine Zahl
+  // in [0, 1) — dieselbe Bühne, auf der RARITY_CHANCE seine Prozente definiert.
+  const roll = hash(seed) / 0x1_0000_0000
+  let acc = 0
+  for (const step of RARITIES) {
+    acc += RARITY_CHANCE[step]
+    if (roll < acc) return step
+  }
+  // Nur als Schutz gegen Gleitkomma-Rundung, falls acc knapp unter 1 bleibt.
+  return RARITIES[RARITIES.length - 1] ?? 'gewoehnlich'
+}
+
+/**
  * Zieht einen noch nicht besessenen Gegenstand.
  *
  * Läuft der verlangte Topf leer, wird **nicht** auf ein Duplikat ausgewichen. Es
  * wird zuerst in der nächstniedrigeren Stufe derselben Kategorie gesucht — wer eine
- * epische Truhe öffnet, soll nicht leer ausgehen, nur weil die epischen Umhänge alle
+ * seltene Truhe öffnet, soll nicht leer ausgehen, nur weil die seltenen Umhänge alle
  * sind. Erst wenn auch dort nichts frei ist, gibt es Gold.
  */
 export function drawLoot(
@@ -81,11 +106,11 @@ export function drawLoot(
   seed: string,
 ): Drop {
   const goldFor: Record<Rarity, number> = {
-    gewoehnlich: 20, selten: 60, episch: 160, legendaer: 400,
+    gewoehnlich: 20, ungewoehnlich: 60, selten: 160, aussergewoehnlich: 400,
   }
 
-  // Von der verlangten Stufe abwärts, nie aufwärts: eine leere epische Kiste
-  // darf keinen legendären Gegenstand ausschütten.
+  // Von der verlangten Stufe abwärts, nie aufwärts: eine leere seltene Kiste
+  // darf keinen außergewöhnlichen Gegenstand ausschütten.
   const start = RARITIES.indexOf(rarity)
   for (let i = start; i >= 0; i--) {
     const step = RARITIES[i]
@@ -127,10 +152,11 @@ export function setCompletedBy(
 /**
  * Wie lange die Keine-Duplikate-Regel in einem Topf noch trägt.
  *
- * Konzept V1 verlangt die Regel, sagt aber nicht, wie groß die Töpfe sein müssen.
- * Vier Kategorien × vier Stufen sind sechzehn Töpfe; bei acht Quests am Tag ist ein
- * Topf mit zwanzig Einträgen in gut zwei Wochen leer. Diese Funktion macht das
- * messbar, statt es zu schätzen — sie gehört in einen Test, nicht in eine Annahme.
+ * Concept V2 verlangt die Regel (docs/CONCEPT.md §4), sagt aber nicht, wie groß die
+ * Töpfe sein müssen. Vier Kategorien × vier Stufen sind sechzehn Töpfe; bei acht
+ * Quests am Tag ist ein Topf mit zwanzig Einträgen in gut zwei Wochen leer. Diese
+ * Funktion macht das messbar, statt es zu schätzen — sie gehört in einen Test,
+ * nicht in eine Annahme.
  */
 export function drawsRemaining(
   catalogue: readonly CatalogueItem[],
@@ -154,7 +180,7 @@ export function drawsRemaining(
  */
 export const MIN_POOL_SIZE: Record<Rarity, number> = {
   gewoehnlich: 40,
-  selten: 20,
-  episch: 12,
-  legendaer: 12,
+  ungewoehnlich: 20,
+  selten: 12,
+  aussergewoehnlich: 12,
 }

--- a/lib/loot/rewards.ts
+++ b/lib/loot/rewards.ts
@@ -1,0 +1,36 @@
+/**
+ * Allgemeine Belohnungsformel nach ADR-030 und docs/CONCEPT.md §4:
+ *
+ *   XP:   1 tatsächlich fokussierte Minute = 1 XP.
+ *   Gold: 1 Gold pro 5 erfolgreich abgeschlossenen Fokusminuten.
+ *
+ * Keine Klassen-Passive, keine Charakter-Boni, keine XP-Multiplikatoren (#15).
+ *
+ * Abbruch erhält XP für tatsächlich fokussierte Minuten, aber kein
+ * Questabschluss-Gold und keine Truhe (ADR-030). Das ist bereits so in der
+ * Supabase-RPC `complete_first_light_session` (supabase/migrations/) für die
+ * erste, deterministische Quest umgesetzt. Diese Datei bildet dafür nur die
+ * allgemeine, wiederverwendbare Formel für künftige Quests ab — sie kennt
+ * selbst keinen Abbruch-Zustand, weil es dafür nichts zu berechnen gibt: Ein
+ * Abbruch ruft `questCompletionXp` mit den tatsächlich fokussierten Minuten auf
+ * und `questCompletionGold` schlicht gar nicht.
+ *
+ * Rein: keine React-Importe, kein Zugriff auf Datenbank oder Uhr.
+ */
+
+/** 1 XP pro tatsächlich fokussierter Minute — unabhängig von Erfolg oder Abbruch. */
+export function questCompletionXp(focusedMinutes: number): number {
+  if (focusedMinutes <= 0) return 0
+  return focusedMinutes
+}
+
+/**
+ * 1 Gold pro 5 erfolgreich abgeschlossenen Fokusminuten, abgerundet.
+ *
+ * Nur für einen tatsächlichen Questabschluss aufrufen — bei Abbruch gibt es
+ * kein Questabschluss-Gold (ADR-030), diese Funktion also gar nicht erst rufen.
+ */
+export function questCompletionGold(durationMinutes: number): number {
+  if (durationMinutes <= 0) return 0
+  return Math.floor(durationMinutes / 5)
+}


### PR DESCRIPTION
## Bezug

Referenziert #15. **Schließt #15 nicht vollständig** — siehe „Was NICHT in diesem PR steckt" unten.

## Was gemacht wurde

`lib/loot/draw.ts` war explizit als „Konzept V1 §10" gekennzeichnet und benannte die vier Seltenheitsstufen `gewoehnlich | selten | episch | legendaer` mit `RARITY_CHANCE = {gewoehnlich: 0.6, selten: 0.27, episch: 0.11, legendaer: 0.02}`.

Nach ADR-021 (Concept V2, `docs/DECISIONS.md`) und `docs/CONCEPT.md` §4 lauten die vier Stufen aber **Gewöhnlich 60 % · Ungewöhnlich 27 % · Selten 11 % · Außergewöhnlich 2 %**. Der alte Code ordnete der 27-%-Stufe den Namen „selten" und der 11-%-Stufe den Namen „episch" zu — nach Concept V2 heißt die 27-%-Stufe „Ungewöhnlich" und die 11-%-Stufe „Selten". **Das ist keine Umbenennung um ihrer selbst willen, sondern eine echte inhaltliche Fehlzuordnung zwischen Stufenname und Wahrscheinlichkeit**, die z. B. in jeder UI, die künftig „Selten" anzeigt, die falsche 27-%-Chance kommuniziert hätte statt der tatsächlichen 11 %.

Im Einzelnen:

1. **`lib/loot/draw.ts`**: `Rarity`-Typ, `RARITY_CHANCE`, `MIN_POOL_SIZE` und die Gold-Ersatzwerte auf die vier ADR-021-Stufen umbenannt. Alle Kommentare, die „Konzept V1" referenzierten, inhaltlich geprüft (nicht nur das Wort ersetzt) und auf Concept V2 / ADR-021 aktualisiert. Dabei ist mir zusätzlich aufgefallen: Der bestehende Kommentar begründete den deterministischen Seed mit „damit sehen alle Party-Mitglieder dieselbe Party-Truhe" — das widerspricht ADR-025 (keine Party-Truhe, jede Person bekommt individuelle Rewards). Da ich ohnehin denselben Kommentarblock wegen der V1-Referenz anfassen musste, habe ich das mitkorrigiert: Determinismus dient jetzt nachvollziehbar der Testbarkeit/serverseitigen Reproduzierbarkeit, nicht geteiltem Loot. Die zugehörige Testbeschreibung in `draw.test.ts` wurde ebenso umformuliert (Funktion/Verhalten unverändert, nur die irreführende Begründung entfernt).
2. **`rollRarity(seed)`** (neu in `draw.ts`): zieht deterministisch (kein `Math.random()`, nutzt die bestehende `hash()`-Funktion) eine Stufe gewichtet nach `RARITY_CHANCE`. Bisher gab es dafür keine Funktion — `drawLoot` bekommt die Stufe als Parameter statt sie selbst zu würfeln.
3. **Verteilungstest**: `draw.test.ts` schickt 20.000 verschiedene Seeds durch `rollRarity`, berechnet die empirische Häufigkeit je Stufe und prüft sie gegen `RARITY_CHANCE` mit ±2 Prozentpunkten Toleranz — das in #15 explizit geforderte Akzeptanzkriterium „Wahrscheinlichkeitsverteilung automatisiert getestet".
4. **`lib/loot/rewards.ts`** (neu): `questCompletionXp(focusedMinutes)` (1:1) und `questCompletionGold(durationMinutes)` (`Math.floor(durationMinutes / 5)`) nach ADR-030. Tests decken exakt die im Issue genannten Fälle ab: 15→3, 25→5, 50→10 Gold. Als Kommentar dokumentiert (nicht als Code, da hier kein Abbruch-Zustand zu berechnen ist): Abbruch erhält XP für tatsächlich fokussierte Minuten, aber kein Questabschluss-Gold und keine Truhe — das ist bereits so in der Supabase-RPC `complete_first_light_session` für die erste Quest umgesetzt; diese Datei bildet nur die allgemeine, wiederverwendbare Formel für künftige Quests ab.
5. **`content/items.de.json`**: alle `rarity`-Werte der 336 Katalogeinträge ummappt (`selten`→`ungewoehnlich`, `episch`→`selten`, `legendaer`→`aussergewoehnlich`, `gewoehnlich` unverändert). Verifiziert per Diff: nur die 176 betroffenen `"rarity"`-Zeilen geändert, sonst nichts. Verteilung nach Migration: 160/80/48/48 — passt exakt zu `MIN_POOL_SIZE` (40/20/12/12 je der vier Kategorien).
6. **ID-Präfixe nachgezogen** (Folge-Commit `95f2dde`): Die Katalog-IDs enthielten die alte Stufen-Abkürzung eingebettet (z. B. `cha-sel-zunftmantel` für die vormalige `selten`-Stufe), passten nach der Rarity-Migration also nicht mehr zum tatsächlichen `rarity`-Feld. Eindeutig auflösbar, da alle 336 Einträge genau eines von vier Präfixen (`gew`/`sel`/`epi`/`leg`) tragen: `sel`→`ung`, `epi`→`sel`, `leg`→`aus`, `gew` unverändert. Verifiziert: 336 von 336 IDs weiterhin eindeutig, keine Kollisionen, keine bestehenden Referenzen auf die alten IDs (das allgemeine Loot-System ist noch an keine Datenbank angebunden).
7. Bestehende Tests (`draw.test.ts`, `catalogue.test.ts`) an die neuen Bezeichnungen angepasst, `items.test.ts` unverändert gelassen (nutzt einen eigenen, unabhängigen englischen `Rarity`-Typ für den Item-Baukasten in `lib/loot/items.ts` — nicht Teil dieser Migration, siehe unten).

## Was NICHT in diesem PR steckt — und warum

- **Kein neuer Server-Endpunkt / keine neue RPC-Funktion**, die `rollRarity`/`drawLoot`/`rewards.ts` tatsächlich aufruft.
- **Keine neue Datenbank-Tabelle oder -Migration** für ein Inventar/Owned-Items.
- **Kein UI** für Truhenöffnung, Inventar oder Charakterbogen.
- **Keine Änderung an `app/quest/first-light/*`** oder der bestehenden Supabase-Migration für die deterministische erste Truhe (ADR-031, Phase 1) — die bleibt exakt wie sie ist.

Grund: Die vollständige Anbindung an echte Quests hängt an #26 (Questpool-Erweiterung) und #17 (Inventar-UI). Beide Issues sind laut ihrem eigenen Text explizit gegated: „Erst starten, wenn der 15-Minuten-Vertical-Slice #35 produktseitig abgenommen ist" (#26) bzw. „Phase 2 – nicht Teil des aktuellen Vertical Slice #35" (#17). Dieser PR bereitet nur die korrekte, getestete Bibliothekslogik vor, die #26/#17 später verwenden können. **#15 bleibt daher offen**, bis das Server-Wiring in einem eigenen, später folgenden PR nachgezogen ist.

`lib/loot/items.ts` (der Item-Baukasten mit `Rarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary'`) ist bewusst unverändert: Das ist ein separater, unabhängiger Typ für die deterministische Ableitung des Item-Aussehens aus einer Kennung, nicht die Konzept-Seltenheitsstufe aus `draw.ts`/`items.de.json`. Beide Rarity-Konzepte kollidieren nicht, weil sie an unterschiedlichen Stellen verwendet werden.

## Verifikation

Alle fünf CI-Schritte lokal grün:

```
npm ci
npm run lint       # 0 Fehler (2 Vorbestehende Warnungen, unverändert)
npm run typecheck  # 0 Fehler
npm test           # 8 Dateien, 104 Tests, alle grün
npm run build      # erfolgreich
```

## Technical-Owner-Review

Technische Freigabe erteilt, siehe [Review-Kommentar](https://github.com/yamahabenny-gif/pomodoro-dnd/pull/71#issuecomment-5557809510). Die dort benannte Auflage (PR-Beschreibung war an einer Stelle nicht mehr deckungsgleich mit dem Diff — die ID-Migration aus Commit `95f2dde` fehlte in der Beschreibung) ist mit dieser Überarbeitung behoben.
