### PR TITLE
#SENDEV next-env.d.ts gitignoren und von ESLint ausnehmen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules/
 .next/
+# Von Next.js bei jedem build/dev neu geschrieben (Next 15 ergaenzt bei
+# aktivem Typed-Routes-Feature eine Triple-Slash-Referenz, die gegen
+# @typescript-eslint/triple-slash-reference verstoesst - siehe #73).
+next-env.d.ts
 out/
 build/
 .env

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,10 @@ export default [
     extends: ['next/core-web-vitals', 'next/typescript'],
   }),
   {
-    ignores: ['.next/**', 'node_modules/**'],
+    // next-env.d.ts wird von Next.js bei jedem build/dev neu geschrieben
+    // und darf laut eigenem Dateikommentar nicht manuell gepflegt werden
+    // (siehe .gitignore und #73) - ESLint soll den generierten Inhalt
+    // deshalb nie bewerten, unabhaengig davon, ob die Datei gerade existiert.
+    ignores: ['.next/**', 'node_modules/**', 'next-env.d.ts'],
   },
 ]

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,4 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// This file is generated/maintained by Next.js conventions.


### PR DESCRIPTION
Closes #73

## Problem
\`next-env.d.ts\` war eingecheckt, wird aber von Next.js bei jedem \`next build\`/\`next dev\` automatisch neu geschrieben (Next 15 ergänzt bei aktivem Typed-Routes-Feature eine Triple-Slash-Referenz auf \`./.next/types/routes.d.ts\`). Das verletzt \`@typescript-eslint/triple-slash-reference\`. In CI unsichtbar, weil dort \`lint\` vor \`build\` läuft — real reproduzierbar bei \`npm run build && npm run lint\` in dieser Reihenfolge, wie im Issue beschrieben.

## Fix — zwei Teile, nicht nur einer
- \`.gitignore\`: Datei nicht mehr tracken.
- \`eslint.config.mjs\`: Datei zusätzlich von ESLint ausnehmen — ein lokaler Build erzeugt sie ja trotzdem weiterhin mit der Referenz, das Gitignore allein hätte das ursprüngliche Lint-Problem nicht gelöst.

## Verifikation
Als vollständige Sequenz gegen einen simulierten frischen Checkout (Datei vorher gelöscht):

```
npm run lint       # ohne next-env.d.ts vorhanden — 0 Fehler (2 vorbestehende Warnings)
npm run typecheck  # funktioniert auch ohne vorhandene Datei (Glob-Include, kein Hard-Error)
npm test           # 104/104
npm run build      # erzeugt next-env.d.ts neu, mit Triple-Slash-Referenz
npm run lint       # danach erneut geprüft — weiterhin 0 Fehler
```

Kein App-Code verändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)