### PR TITLE
#SENDEV ADR-040: ops_heartbeats-Migration nachtragen

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -90,6 +90,14 @@ Drei persistente Akte mit Rasten; Boss/Höhepunkt in Akt III. Kein 90-Minuten-Da
 **Alternative:** Render beibehalten — abgelehnt, da der VPS technisch überlegen ist (kein Cold-Start, mehr Ressourcen, volle Kontrolle) und ohnehin bereits verfügbar ist.  
 **Grund:** Bessere technische Eignung bei gleichen Kosten (keine). Wichtig festzuhalten: Der VPS **vereinheitlicht Preview und Produktion nicht** — Ionos und Hostinger bleiben zwei verschiedene Anbieter. Das in ADR-037 benannte Grundrisiko (Preview läuft auf anderer Laufzeitumgebung als Produktion) bleibt bestehen, wird aber durch echtes Node.js auf beiden Seiten deutlich kleiner als bei einer Edge-Runtime.
 
+### ADR-040 · Supabase-Aktivitäts-Heartbeat gegen automatisches Pausieren
+**Status:** angenommen · 2026-09-06  
+**Kontext:** Supabase pausiert Free-Plan-Projekte nach etwa sieben Tagen ohne Aktivität automatisch. Während einer offenen, nicht terminierten Entwicklungsphase ist das ein reales Betriebsrisiko — HERMES (Webadmin) hat es auf #51 aufgeworfen und nach Freigabe umgesetzt, direkt gegen die Live-Instanz, **ohne begleitende Migration im Repository**.  
+**Entscheidung:** Alle drei Kalendertage schreibt ein Betriebsjob genau einen Datensatz (`service = 'pomodoro-dnd'`, aktueller Git-Commit, Zeitstempel) in eine dedizierte Tabelle `public.ops_heartbeats` — siehe Migration `20260906143000_ops_heartbeats.sql` (nachträglich ins Repo aufgenommen, damit Schema und Git wieder übereinstimmen; das eigentliche `create table` wurde bereits vorher live angewendet). Ausdrücklich **keine** Berührung von `profiles`, `characters`, `focus_sessions` oder `unlocks`. Jede DB-Schreiboperation außerhalb dieses einen Heartbeat-Datensatzes bleibt freigabepflichtig durch den Account-Owner.  
+**Alternative:** Rein lesende API-Aktivität ohne DB-Schreibvorgang — laut Supabase-Doku unter Umständen ausreichend, aber nicht zuverlässig genug geprüft, um sich allein darauf zu verlassen.  
+**Grund:** Verhindert ein unbeabsichtigtes Pausieren des Projekts während längerer Entwicklungspausen, mit minimaler, klar abgegrenzter Schreibfläche.  
+**Offener Punkt:** Das ausführende Script (\`~/.hermes/scripts/pomodoro_dnd_heartbeat.py\`) läuft aktuell außerhalb dieses Repositories, in HERMES' eigener Umgebung, mit dem vollprivilegierten \`service_role\`-Key — für niemand sonst einsehbar oder review-fähig. Sollte perspektivisch als Skript ins Repo (z. B. \`scripts/\`) überführt werden, damit auch der Automatisierungscode selbst der "Was nicht in GitHub steht, existiert nicht"-Regel aus `docs/WORKFLOW.md` folgt.
+
 ---
 
 ## Concept-V2-Entscheidungen

--- a/supabase/migrations/20260906143000_ops_heartbeats.sql
+++ b/supabase/migrations/20260906143000_ops_heartbeats.sql
@@ -1,0 +1,25 @@
+-- Retrofit: dokumentiert im Repo, was HERMES (Webadmin) am 2026-09-06 bereits
+-- direkt gegen die Live-Instanz angewendet hat (siehe Kommentare auf #51,
+-- 14:29-15:46 Uhr). Ohne diese Datei war das Schema der Datenbank nicht mehr
+-- deckungsgleich mit dem, was im Repository nachvollziehbar ist - genau das
+-- widerspricht docs/WORKFLOW.md ("Ergebnisse ins Repo schreiben, nicht nur
+-- in den Chat"). `if not exists`/idempotente Grants, damit ein erneutes
+-- Anwenden gegen die bereits laufende Instanz nicht fehlschlaegt.
+--
+-- Zweck: alle drei Kalendertage ein Betriebs-Heartbeat, damit das Supabase-
+-- Free-Plan-Projekt nicht wegen Inaktivitaet automatisch pausiert wird
+-- (Supabase pausiert Free-Projekte nach sieben Tagen ohne Aktivitaet).
+-- Beruehrt ausschliesslich diesen einen dedizierten Datensatz - keine
+-- fachlichen Tabellen (profiles/characters/focus_sessions/unlocks).
+
+create table if not exists public.ops_heartbeats (
+  service text primary key,
+  commit_sha text not null,
+  source text not null,
+  touched_at timestamptz not null
+);
+
+alter table public.ops_heartbeats enable row level security;
+
+revoke all on public.ops_heartbeats from public, anon, authenticated;
+grant select, insert, update on public.ops_heartbeats to service_role;


### PR DESCRIPTION
## Ziel
Bringt Git und die tatsächliche Datenbank wieder in Deckung. HERMES hat auf #51 einen Drei-Tage-Supabase-Heartbeat eingerichtet (gegen automatisches Pausieren des Free-Plan-Projekts), das `create table` dabei aber direkt gegen die Live-Instanz angewendet — ohne begleitende Migration im Repo.

## Änderungen
- **Migration `20260906143000_ops_heartbeats.sql`**: transkribiert exakt, was laut HERMES' Kommentaren auf #51 bereits live angewendet wurde — `ops_heartbeats`-Tabelle, RLS, Grants nur für `service_role`. Mit `if not exists`/idempotenten Grants, damit ein erneutes Anwenden gegen die bereits laufende Instanz nicht fehlschlägt.
- **ADR-040** in `docs/DECISIONS.md`: dokumentiert Kontext und Entscheidung, plus einen explizit offen gehaltenen Punkt — das ausführende Script liegt weiterhin außerhalb des Repos (`~/.hermes/scripts/pomodoro_dnd_heartbeat.py`, in HERMES' eigener Umgebung, mit dem vollprivilegierten `service_role`-Key). Das wird hier nicht gelöst, nur sichtbar gemacht statt stillschweigend hingenommen.

## Kein App-Code verändert

## Verifikation
- [x] `npm run lint` (2 vorbestehende Warnings, unverändert)
- [x] `npm run typecheck`
- [x] `npm test` (104/104)

🤖 Generated with [Claude Code](https://claude.com/claude-code)