### PR TITLE
#SENDEV basePath für /preview und /uat konfigurierbar machen

### DIFF
--- a/app/account/account-form.tsx
+++ b/app/account/account-form.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useState } from 'react'
 import { createSupabaseBrowserClient } from '../../lib/supabase/client'
+import { withBasePath } from '../../lib/base-path'
 
 type Status = 'idle' | 'loading' | 'sent' | 'offline' | 'error'
 
@@ -45,7 +46,7 @@ export function AccountForm({ expired }: { expired: boolean }) {
       const supabase = createSupabaseBrowserClient()
       const { error } = await supabase.auth.signInWithOtp({
         email,
-        options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+        options: { emailRedirectTo: `${window.location.origin}${withBasePath('/auth/callback')}` },
       })
 
       if (error) throw error

--- a/app/adventure-book/page.tsx
+++ b/app/adventure-book/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createSupabaseServerClient } from '../../lib/supabase/server'
+import { withBasePath } from '../../lib/base-path'
 import styles from './adventure-book.module.css'
 
 export const dynamic = 'force-dynamic'
@@ -36,7 +37,7 @@ export default async function AdventureBookPage() {
         <article className={styles.quest} aria-labelledby="quest-title">
           <div className={styles.questArt} aria-hidden="true">
             <svg viewBox="0 0 1600 900" focusable="false">
-              <use href="/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-01" />
+              <use href={withBasePath('/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-01')} />
             </svg>
           </div>
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '../../../lib/supabase/server'
+import { withBasePath } from '../../../lib/base-path'
 
 export async function GET(request: Request) {
   const url = new URL(request.url)
@@ -7,7 +8,7 @@ export async function GET(request: Request) {
   const origin = url.origin
 
   if (!code) {
-    return NextResponse.redirect(`${origin}/account?error=expired`)
+    return NextResponse.redirect(`${origin}${withBasePath('/account?error=expired')}`)
   }
 
   try {
@@ -15,11 +16,11 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
 
     if (error) {
-      return NextResponse.redirect(`${origin}/account?error=expired`)
+      return NextResponse.redirect(`${origin}${withBasePath('/account?error=expired')}`)
     }
 
-    return NextResponse.redirect(`${origin}/character`)
+    return NextResponse.redirect(`${origin}${withBasePath('/character')}`)
   } catch {
-    return NextResponse.redirect(`${origin}/account?error=expired`)
+    return NextResponse.redirect(`${origin}${withBasePath('/account?error=expired')}`)
   }
 }

--- a/app/camp/page.tsx
+++ b/app/camp/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { createSupabaseServerClient } from '../../lib/supabase/server'
+import { withBasePath } from '../../lib/base-path'
 import styles from './camp.module.css'
 
 export const dynamic = 'force-dynamic'
@@ -40,13 +41,13 @@ export default async function CampPage() {
     <main id="main-content" className={styles.shell}>
       <section className={styles.stage} aria-labelledby="camp-title">
         <svg className={styles.campArt} viewBox="0 0 1600 900" aria-hidden="true" focusable="false">
-          <use href="/assets/phase1-art-pack.svg#camp-stage-01-base" />
-          {lanternVisible ? <use href="/assets/phase1-art-pack.svg#camp-stage-01-lantern" /> : null}
+          <use href={withBasePath('/assets/phase1-art-pack.svg#camp-stage-01-base')} />
+          {lanternVisible ? <use href={withBasePath('/assets/phase1-art-pack.svg#camp-stage-01-lantern')} /> : null}
         </svg>
 
         <div className={styles.character} aria-label={`${character.name}, dein Charakter`}>
           <svg viewBox="0 0 220 260" aria-hidden="true" focusable="false">
-            <use href={`/assets/phase1-art-pack.svg#${characterAsset}`} />
+            <use href={withBasePath(`/assets/phase1-art-pack.svg#${characterAsset}`)} />
           </svg>
           <span>{character.name}</span>
         </div>
@@ -61,7 +62,7 @@ export default async function CampPage() {
 
         <Link className={styles.bookAction} href="/adventure-book" aria-label="Abenteuerbuch öffnen">
           <svg viewBox="0 0 320 220" aria-hidden="true" focusable="false">
-            <use href="/assets/phase1-art-pack.svg#camp-adventure-book" />
+            <use href={withBasePath('/assets/phase1-art-pack.svg#camp-adventure-book')} />
           </svg>
           <span>Abenteuerbuch öffnen</span>
         </Link>

--- a/app/character/character-creator.tsx
+++ b/app/character/character-creator.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { createSupabaseBrowserClient } from '../../lib/supabase/client'
+import { withBasePath } from '../../lib/base-path'
 import styles from './character.module.css'
 
 const ancestries = [
@@ -135,7 +136,7 @@ export function CharacterCreator({ userId, initialCharacter }: { userId: string;
                 onClick={() => update('ancestry', ancestry.id)}
               >
                 <svg viewBox="0 0 220 260" aria-hidden="true" focusable="false">
-                  <use href={`/assets/phase1-art-pack.svg#${ancestry.asset}`} />
+                  <use href={withBasePath(`/assets/phase1-art-pack.svg#${ancestry.asset}`)} />
                 </svg>
                 <strong>{ancestry.label}</strong>
                 <span>{ancestry.note}</span>
@@ -197,7 +198,7 @@ function CharacterPreview({ draft, asset }: { draft: CharacterDraft; asset: stri
   return (
     <svg className={styles.characterPreview} viewBox="0 0 512 512" focusable="false">
       <g transform={`translate(256 0) scale(${bodyScale} 1) translate(-256 0)`}>
-        <use href={`/assets/phase1-art-pack.svg#${asset}`} />
+        <use href={withBasePath(`/assets/phase1-art-pack.svg#${asset}`)} />
       </g>
       <circle className={styles.skinLayer} cx="256" cy="150" r={draft.ancestry === 'goblin' ? 60 : 69} fill={skinColor} />
       {draft.ancestry === 'elf' ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,10 @@
 import Link from 'next/link'
+import { withBasePath } from '../lib/base-path'
 
 function ForestLayer({ id, className }: { id: string; className: string }) {
   return (
     <svg className={className} viewBox="0 0 1600 900" aria-hidden="true" focusable="false">
-      <use href={`/assets/phase1-art-pack.svg#${id}`} />
+      <use href={withBasePath(`/assets/phase1-art-pack.svg#${id}`)} />
     </svg>
   )
 }

--- a/app/quest/first-light/quest-runner.tsx
+++ b/app/quest/first-light/quest-runner.tsx
@@ -8,6 +8,7 @@ import { useReducedMotion } from '../../../lib/hooks/use-reduced-motion'
 import { deriveQuestPhase, FocusSessionRow, toRestSession, toTimerSession } from '../../../lib/timer/first-light'
 import { formatRemaining, snapshot } from '../../../lib/timer/session'
 import { layerOffset } from '../../../lib/timer/journey'
+import { withBasePath } from '../../../lib/base-path'
 import styles from './first-light.module.css'
 
 type SupabaseClient = ReturnType<typeof createSupabaseBrowserClient>
@@ -173,7 +174,7 @@ export function QuestRunner({
   async function leaveQuest() {
     if (!session) return
     await callRpc(supabase, 'cancel_focus_session', { p_session_id: session.id })
-    window.location.href = '/camp'
+    window.location.href = withBasePath('/camp')
   }
 
   async function finishRest() {

--- a/app/quest/first-light/quest-runner.tsx
+++ b/app/quest/first-light/quest-runner.tsx
@@ -289,7 +289,7 @@ function Departure() {
         focusable="false"
         className={styles.departureArt}
       >
-        <use href="/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-01" />
+        <use href={withBasePath('/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-01')} />
       </svg>
       <div className={styles.departureCopy}>
         <p className="eyebrow">Aufbruch</p>
@@ -331,7 +331,7 @@ function FocusScene({
             className={styles.beat}
             data-active={index === beat}
           >
-            <use href={`/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-0${index + 1}`} />
+            <use href={withBasePath(`/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-0${index + 1}`)} />
           </svg>
         ))}
       </div>
@@ -343,7 +343,7 @@ function FocusScene({
         className={styles.silhouette}
         style={{ transform: `translateX(${silhouetteX}px)` }}
       >
-        <use href="/assets/phase1-art-pack.svg#journey-silhouette" />
+        <use href={withBasePath('/assets/phase1-art-pack.svg#journey-silhouette')} />
       </svg>
 
       <div className={styles.timerPanel}>
@@ -384,7 +384,7 @@ function Resolution({
   return (
     <section className={styles.card} aria-labelledby="resolution-title">
       <svg viewBox="0 0 1600 900" aria-hidden="true" focusable="false" className={styles.resolutionArt}>
-        <use href="/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-04" />
+        <use href={withBasePath('/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-04')} />
       </svg>
       <p className="eyebrow">Questabschluss</p>
       <h1 id="resolution-title">Das Licht ist erreicht.</h1>
@@ -432,7 +432,7 @@ function Rest({
         focusable="false"
         className={styles.restArt}
       >
-        <use href="/assets/phase1-art-pack.svg#rest-campfire" />
+        <use href={withBasePath('/assets/phase1-art-pack.svg#rest-campfire')} />
       </svg>
       <div className={styles.restCopy}>
         <p className="eyebrow" id="rest-title">
@@ -461,7 +461,7 @@ function ChestReady({ onOpen }: { onOpen: () => void }) {
   return (
     <section className={styles.card} aria-labelledby="chest-title">
       <svg viewBox="0 0 1600 900" aria-hidden="true" focusable="false" className={styles.chestArt}>
-        <use href="/assets/phase1-art-pack.svg#chest-closed" />
+        <use href={withBasePath('/assets/phase1-art-pack.svg#chest-closed')} />
       </svg>
       <p className="eyebrow">Nach der Rast</p>
       <h1 id="chest-title">Deine erste Truhe wartet.</h1>
@@ -476,7 +476,7 @@ function Done() {
   return (
     <section className={styles.card} aria-labelledby="done-title">
       <svg viewBox="0 0 1600 900" aria-hidden="true" focusable="false" className={styles.chestArt}>
-        <use href="/assets/phase1-art-pack.svg#chest-open" />
+        <use href={withBasePath('/assets/phase1-art-pack.svg#chest-open')} />
       </svg>
       <p className="eyebrow">Alte Weglaterne gefunden</p>
       <h1 id="done-title">Der Weg zurück ist erhellt.</h1>

--- a/docs/PREVIEW-DEPLOYMENT.md
+++ b/docs/PREVIEW-DEPLOYMENT.md
@@ -1,12 +1,31 @@
 # Internes Phase-1-Preview
 
-> **Aktueller Preview-Pfad: Ionos-VPS mit Plesk (befristete Dev-Preview, ADR-039).**
-> Produktionsziel bleibt Hostinger / `focus.lang-jamin.de` (ADR-036) — daran ändert
-> die VPS-Übergangslösung nichts, Ionos und Hostinger sind zwei unabhängige
-> Anbieter. Sobald der Produktions-Cutover ansteht (Issue #3), wird auf
-> Hostinger als tatsächliches Deployment-Ziel umgestellt.
+> **Aktueller Preview-Pfad: Ionos-VPS, Ubuntu 24.04 + Node.js 22 + NGINX direkt
+> (befristete Dev-Preview, ADR-039).**
+> Der ursprüngliche Handoff ging von Plesk auf diesem VPS aus. Der tatsächliche
+> Read-back durch HERMES auf dem realen Zielsystem (Issue #51) hat gezeigt:
+> **kein Plesk installiert** (kein `/usr/local/psa`, kein `psa`-Paket, keine
+> Plesk-Prozesse/-Ports). HERMES ist deshalb bewusst auf die in diesem
+> Dokument bereits als Alternative vorgesehene direkte Ubuntu-Variante
+> umgeschwenkt: Node.js 22 + NGINX ohne Plesk-Panel, Repo unter
+> `/srv/pomodoro-dnd`. Das ist der Weg, der tatsächlich läuft — der
+> Plesk-Abschnitt weiter unten bleibt als Referenz stehen, falls auf diesem
+> oder einem anderen VPS später doch Plesk zur Verfügung steht, ist aber
+> **nicht der aktuelle Stand**.
+>
+> Produktionsziel bleibt Hostinger / `focus.lang-jamin.de` (ADR-036) — daran
+> ändert die VPS-Übergangslösung nichts, Ionos und Hostinger sind zwei
+> unabhängige Anbieter. Sobald der Produktions-Cutover ansteht (Issue #3),
+> wird auf Hostinger als tatsächliches Deployment-Ziel umgestellt.
+>
+> Die gewünschte Topologie ist **kein separates Sub-Domain-Deployment**,
+> sondern zwei Pfade unter derselben Domain: `focus.lang-jamin.de/preview/`
+> (laufende Entwicklung) und `focus.lang-jamin.de/uat/` (finale
+> Freigabeprüfung durch Daisy als Super User). Siehe Abschnitt
+> "Zwei Pfade unter einer Domain: `/preview/` und `/uat/`" weiter unten für
+> das konkrete Muster.
 
-Dieses Dokument ist der technische Handoff für den internen Preview-Stand. Der Developer bereitet den deploybaren Stand im Repository vor; die Einrichtung des jeweiligen Hosting-Accounts erfolgt durch die dafür zuständige Person (aktuell: Ionos-VPS/Plesk-Einrichtung, später: Webdesigner für Hostinger).
+Dieses Dokument ist der technische Handoff für den internen Preview-Stand. Der Developer bereitet den deploybaren Stand im Repository vor; die Einrichtung des jeweiligen Hosting-Accounts erfolgt durch die dafür zuständige Person (aktuell: Ionos-VPS-Einrichtung durch HERMES, später: Webdesigner für Hostinger).
 
 ## Ziel
 
@@ -56,6 +75,42 @@ npm run start
 
 `next start` liest den `PORT`, den der jeweilige Host vorgibt, automatisch — keine Code-Anpassung nötig. Für Hosts, die eine **Startdatei statt eines Startkommandos** verlangen (Plesk/Passenger, siehe unten), gibt es zusätzlich `npm run start:plesk` (`node server.js`), ein minimaler Next.js Custom Server. Beide Wege nutzen denselben `npm run build`-Output.
 
+### `basePath` für `/preview/` und `/uat/` — Build-Zeit-Variable `NEXT_BASE_PATH`
+
+`next.config.mjs` liest `basePath` aus der Build-Zeit-Umgebungsvariable
+`NEXT_BASE_PATH`:
+
+```js
+const basePath = process.env.NEXT_BASE_PATH || ''
+```
+
+Next.js liest `basePath` beim Build aus und kann ihn zur Laufzeit nicht mehr
+ändern. Ohne die Variable (lokal, oder für einen künftigen
+Produktions-Cutover ohne Pfadpräfix) bleibt `basePath` leer wie bisher —
+`npm run build` ohne `NEXT_BASE_PATH` verhält sich unverändert.
+
+Für zwei gleichzeitig laufende Instanzen unter derselben Domain
+(`/preview/` und `/uat/`) bedeutet das zwingend **zwei separate Builds**:
+
+```bash
+NEXT_BASE_PATH=/preview npm run build   # → eigenes Build-Verzeichnis/eigener Prozess/Port
+NEXT_BASE_PATH=/uat     npm run build   # → eigenes Build-Verzeichnis/eigener Prozess/Port
+```
+
+Jeder Build erzeugt sein eigenes `.next`-Verzeichnis mit den `/_next`-Asset-
+Pfaden bereits korrekt auf `/preview` bzw. `/uat` präfigiert. Es reicht daher
+**nicht**, einen einzigen Build zu bauen und per NGINX-Pfad-Rewrite auf zwei
+Locations zu verteilen — die beiden `basePath`-Werte gehören zu zwei
+inhaltlich unterschiedlichen Builds. Details zum Prozess-/NGINX-Muster:
+Abschnitt "Zwei Pfade unter einer Domain: `/preview/` und `/uat/`" weiter unten.
+
+Absolute URLs, die die Anwendung selbst zusammenbaut (Supabase-Magic-Link-
+Redirect, der `/auth/callback`-Route-Handler), verwenden dafür die zentrale
+Konstante `lib/base-path.ts` (`BASE_PATH` / `withBasePath()`), die denselben
+Wert über `NEXT_PUBLIC_BASE_PATH` im Client- wie im Server-Code liefert.
+`<Link>` und `redirect()` aus `next/navigation` benötigen das nicht — die
+hängen den `basePath` bereits automatisch an.
+
 ## Benötigte Environment-Variablen
 
 Für Account- und Charakter-Flow werden mindestens benötigt:
@@ -78,15 +133,139 @@ Dieser Wert darf niemals im Client, Build-Output oder Repository erscheinen.
 
 ## Supabase Auth
 
-Damit Magic-Link-/Auth-Callbacks funktionieren, muss die jeweilige Preview-URL in Supabase Auth als erlaubtes Redirect-Ziel hinterlegt werden. Der Callback-Pfad der Anwendung bleibt `/auth/callback`.
+Damit Magic-Link-/Auth-Callbacks funktionieren, muss die jeweilige Preview-URL in Supabase Auth als erlaubtes Redirect-Ziel hinterlegt werden. Der Callback-Pfad der Anwendung bleibt `/auth/callback`, jeweils unter dem `basePath` des Builds.
+
+Für die aktuelle `/preview/`- und `/uat/`-Topologie unter `focus.lang-jamin.de` müssen **beide** folgenden URLs in Supabase unter Authentication → URL Configuration → Redirect URLs eingetragen werden — nicht nur eine:
+
+```text
+https://focus.lang-jamin.de/preview/auth/callback
+https://focus.lang-jamin.de/uat/auth/callback
+```
+
+Fehlt einer der beiden Einträge, schlägt der Magic-Link-Login auf dem jeweils fehlenden Pfad fehl, auch wenn der andere Pfad funktioniert.
 
 Unabhängig vom Hosting-Pfad muss vor dem ersten Test die Migration `20260905090000_focus_session_pause.sql` auf die Supabase-Instanz angewendet werden (ergänzt Pause/Resume auf `focus_sessions`).
 
 ---
 
-## Ionos VPS mit Plesk (befristete Dev-Preview, ADR-039)
+## Ionos VPS: Ubuntu 24.04 + Node.js 22 + NGINX, ohne Plesk (aktueller Weg, ADR-039)
 
-Grund für diesen Pfad: ein Ionos-VPS (Ubuntu 24.04, Plesk, 4 vCore, 4 GB RAM, 120 GB NVMe SSD) ist bereits vorhanden — kostenlos nutzbar, kein Cold-Start wie bei einem Free-Tier, volle Kontrolle über die Node.js-Laufzeit. Details siehe ADR-039 in `docs/DECISIONS.md`.
+Grund für diesen Pfad: ein Ionos-VPS (Ubuntu 24.04, 4 vCore, 4 GB RAM, 120 GB NVMe SSD) ist bereits vorhanden — kostenlos nutzbar, kein Cold-Start wie bei einem Free-Tier, volle Kontrolle über die Node.js-Laufzeit. Details siehe ADR-039 in `docs/DECISIONS.md`.
+
+Der Handoff, der zu ADR-039 führte, ging von vorinstalliertem Plesk aus. Der direkte Read-back auf dem realen VPS durch HERMES (Issue #51) hat gezeigt, dass **kein Plesk vorhanden ist**. HERMES hat daraufhin bewusst die in der ursprünglichen Fassung dieses Dokuments bereits als Alternative genannte direkte Variante gewählt und bereits erfolgreich begonnen:
+
+- Node.js `v22.23.2` installiert (offizieller SHA-256-Download verifiziert), npm `10.9.8`
+- NGINX installiert, aktiviert, aktiv
+- Repo unter `/srv/pomodoro-dnd`, `npm ci` und `npm run build` liefen bereits erfolgreich
+
+Der fehlende Baustein war bislang `basePath`-Unterstützung im Repository für die gewünschte `/preview/` + `/uat/`-Pfadstruktur unter derselben Domain — das liefert dieser PR (siehe Abschnitt "`basePath` für `/preview/` und `/uat/` — Build-Zeit-Variable `NEXT_BASE_PATH`" oben und das konkrete Setup direkt im Anschluss).
+
+### Zwei Pfade unter einer Domain: `/preview/` und `/uat/`
+
+`focus.lang-jamin.de/preview/` (laufende Entwicklung) und `focus.lang-jamin.de/uat/` (finale Freigabeprüfung durch Daisy als Super User) laufen als **zwei unabhängige Next.js-Prozesse** auf demselben VPS, jeweils mit ihrem eigenen `basePath`-Build, ihrem eigenen Port und ihrem eigenen NGINX-`location`-Block. DNS bzw. die gemeinsame Frontdoor route­n nach Pfad, nicht nach Subdomain — deshalb übernimmt NGINX auf dem VPS diese Aufteilung.
+
+**Schritt 1 — zwei Builds.** Am einfachsten mit zwei getrennten Checkouts (robuster für dauerhaften Betrieb, weil `preview` und `uat` unabhängig voneinander aktualisiert werden können, ohne den jeweils anderen Prozess zu unterbrechen); `node_modules` kann zwischen ihnen per Symlink geteilt werden:
+
+```bash
+# einmalig
+git clone <repo-url> /srv/pomodoro-dnd-preview
+git clone <repo-url> /srv/pomodoro-dnd-uat
+
+# je Deployment, für jeden Checkout:
+cd /srv/pomodoro-dnd-preview
+git pull                       # jeweils freigegebener main-Commit
+NEXT_BASE_PATH=/preview \
+NEXT_PUBLIC_SUPABASE_URL=... \
+NEXT_PUBLIC_SUPABASE_ANON_KEY=... \
+npm ci && npm run build
+
+cd /srv/pomodoro-dnd-uat
+git pull
+NEXT_BASE_PATH=/uat \
+NEXT_PUBLIC_SUPABASE_URL=... \
+NEXT_PUBLIC_SUPABASE_ANON_KEY=... \
+npm ci && npm run build
+```
+
+`NEXT_BASE_PATH` muss beim Build gesetzt sein — ohne die Variable baut `npm run build` wie bisher ohne `basePath`.
+
+**Schritt 2 — zwei laufende Prozesse auf zwei Ports**, `NEXT_BASE_PATH` beim Start identisch zum Build-Wert, damit `next start` seine eigenen Assets unter dem richtigen Präfix erwartet:
+
+```bash
+cd /srv/pomodoro-dnd-preview && NEXT_BASE_PATH=/preview PORT=3001 NODE_ENV=production npm run start
+cd /srv/pomodoro-dnd-uat     && NEXT_BASE_PATH=/uat     PORT=3002 NODE_ENV=production npm run start
+```
+
+Für dauerhaften Betrieb je ein systemd-Service (oder `pm2`) pro Prozess mit Auto-Restart, z. B.:
+
+```ini
+# /etc/systemd/system/pomodoro-preview.service
+[Unit]
+Description=pomodoro-dnd preview
+After=network.target
+
+[Service]
+WorkingDirectory=/srv/pomodoro-dnd-preview
+Environment=NEXT_BASE_PATH=/preview
+Environment=PORT=3001
+Environment=NODE_ENV=production
+Environment=NEXT_PUBLIC_SUPABASE_URL=...
+Environment=NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+ExecStart=/usr/bin/npm run start
+Restart=on-failure
+User=hermes-admin
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Analog `pomodoro-uat.service` mit `NEXT_BASE_PATH=/uat`, `PORT=3002` und `WorkingDirectory=/srv/pomodoro-dnd-uat`. Secrets/Env-Werte gehören in die systemd-Unit oder eine per `EnvironmentFile=` eingebundene Datei außerhalb des Repos — nie im Repository.
+
+**Schritt 3 — NGINX-`location`-Blöcke ohne Pfad-Rewriting.** Weil jeder Build seinen `basePath` bereits selbst kennt (alle `/_next`-Assets, internen Links und der Auth-Callback werden bereits unter `/preview/*` bzw. `/uat/*` gerendert), muss NGINX **nur an den richtigen Port weiterleiten, den Pfad aber nicht umschreiben**:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name focus.lang-jamin.de;
+
+    # ... bestehende TLS-Konfiguration, bestehender Root-/Placeholder-Pfad ...
+
+    location /preview/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /uat/ {
+        proxy_pass http://127.0.0.1:3002;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Wichtig: **kein** trailing slash bei `proxy_pass` (also nicht `proxy_pass http://127.0.0.1:3001/;`) und **kein** `rewrite ^/preview/(.*)$ /$1 break;` davor — beides würde den Pfad abschneiden, den der Next.js-Prozess aber selbst inklusive `basePath` erwartet und rendert. Der bestehende Root-Placeholder von `focus.lang-jamin.de` (der eigene `location / { ... }`-Block) bleibt unverändert bestehen; die beiden neuen `location`-Blöcke kommen nur dazu.
+
+**Schritt 4 — Verifikation**, genau wie lokal in diesem Repo vor dem PR getestet:
+
+```bash
+curl -I https://focus.lang-jamin.de/preview/
+curl -I https://focus.lang-jamin.de/uat/
+curl -s https://focus.lang-jamin.de/preview/ | grep -o '/preview/_next/[^"]*' | head -3
+curl -s https://focus.lang-jamin.de/uat/ | grep -o '/uat/_next/[^"]*' | head -3
+```
+
+Beide sollten `200` liefern; die `/_next`-Asset-Pfade im HTML müssen mit `/preview/_next/` bzw. `/uat/_next/` beginnen. Zusätzlich: Supabase-Redirect-URLs für beide Pfade eintragen (siehe Abschnitt "Supabase Auth" oben), danach den Magic-Link-Login auf beiden Pfaden real testen.
+
+### Plesk-Setup (Referenz — aktuell nicht der verwendete Weg)
+
+Der ursprüngliche ADR-039-Handoff ging von vorinstalliertem Plesk aus. Dieser Abschnitt bleibt als Referenz stehen, falls Plesk auf diesem oder einem anderen VPS später doch verfügbar wird — für den aktuellen VPS gilt stattdessen der Abschnitt "Zwei Pfade unter einer Domain" oben.
 
 Setup (einmalig, durch den Account-Owner mit Plesk-/SSH-Zugriff):
 
@@ -125,7 +304,7 @@ Der komplette Vertical-Slice-Pfad ist in `main` enthalten. Der aktuelle Testpfad
 
 Damit ist der in #35 beschriebene Vertical Slice erstmals von vorn bis hinten durchspielbar. Migration `20260905090000_focus_session_pause.sql` muss vor dem Deployment auf die Supabase-Instanz angewendet werden (ergänzt Pause/Resume-Spalten und -Funktionen auf `focus_sessions`).
 
-Damit verbleibt für #35 nur noch die tatsächliche Browser-Abnahme durch den Project Lead — technisch ist der Pfad vollständig. Die VPS-Einrichtung (Plesk, Node.js-App, Environment-Variablen) steht noch aus (siehe oben).
+Damit verbleibt für #35 nur noch die tatsächliche Browser-Abnahme durch den Project Lead — technisch ist der Pfad vollständig. Die App unterstützt jetzt `basePath` per `NEXT_BASE_PATH` (siehe oben); die tatsächliche VPS-Einrichtung (zwei Builds/Prozesse, systemd, NGINX-`location`-Blöcke, DNS-Umschaltung, Environment-Variablen) steht noch aus und liegt bei HERMES (siehe Abschnitt "Ionos VPS: Ubuntu 24.04 + Node.js 22 + NGINX, ohne Plesk" oben).
 
 ## Nicht Bestandteil dieses Handoffs
 
@@ -138,4 +317,4 @@ Damit verbleibt für #35 nur noch die tatsächliche Browser-Abnahme durch den Pr
 
 ## Erfolgskriterium für #51
 
-#51 ist technisch erst dann vollständig abgeschlossen, wenn der aktuelle `main`-Stand tatsächlich auf dem Ionos-VPS bereitgestellt und eine funktionierende Browser-URL zurückgemeldet wurde. Der Repo-Anteil des Developers besteht in einem sauberen, dokumentierten und deploybaren Handoff (dieses Dokument + `server.js`).
+#51 ist technisch erst dann vollständig abgeschlossen, wenn der aktuelle `main`-Stand tatsächlich auf dem Ionos-VPS unter `/preview/` **und** `/uat/` bereitgestellt und funktionierende Browser-URLs zurückgemeldet wurden. Der Repo-Anteil des Developers besteht in einem sauberen, dokumentierten und deploybaren Handoff (dieses Dokument, `server.js`, `next.config.mjs`/`lib/base-path.ts` für `basePath`) — das Umsetzen von Build/Prozessen/NGINX auf dem VPS bleibt weiterhin Aufgabe des Account-Owners (HERMES).

--- a/lib/__tests__/base-path.test.ts
+++ b/lib/__tests__/base-path.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `BASE_PATH`/`withBasePath` lesen `process.env.NEXT_PUBLIC_BASE_PATH` beim
+// Modul-Import aus (genau wie next.config.mjs `basePath` beim Next.js-Build
+// ausliest). Um beide Konfigurationen (kein basePath / `/preview` /
+// `/uat`) in einer Testdatei zu prüfen, muss das Modul nach jeder
+// Env-Änderung frisch importiert werden.
+async function importWithBasePath(value: string | undefined) {
+  vi.resetModules()
+  if (value === undefined) {
+    delete process.env.NEXT_PUBLIC_BASE_PATH
+  } else {
+    process.env.NEXT_PUBLIC_BASE_PATH = value
+  }
+  return import('../base-path')
+}
+
+describe('base-path', () => {
+  const original = process.env.NEXT_PUBLIC_BASE_PATH
+
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.NEXT_PUBLIC_BASE_PATH
+    } else {
+      process.env.NEXT_PUBLIC_BASE_PATH = original
+    }
+    vi.resetModules()
+  })
+
+  it('liefert einen leeren basePath, wenn NEXT_PUBLIC_BASE_PATH nicht gesetzt ist (Standard-Build)', async () => {
+    const { BASE_PATH, withBasePath } = await importWithBasePath(undefined)
+    expect(BASE_PATH).toBe('')
+    expect(withBasePath('/auth/callback')).toBe('/auth/callback')
+    expect(withBasePath('/camp')).toBe('/camp')
+  })
+
+  it('hängt /preview voran, wenn NEXT_BASE_PATH=/preview gebaut wurde', async () => {
+    const { withBasePath } = await importWithBasePath('/preview')
+    expect(withBasePath('/auth/callback')).toBe('/preview/auth/callback')
+    expect(withBasePath('/account?error=expired')).toBe('/preview/account?error=expired')
+    expect(withBasePath('/character')).toBe('/preview/character')
+    expect(withBasePath('/camp')).toBe('/preview/camp')
+  })
+
+  it('hängt /uat voran, wenn NEXT_BASE_PATH=/uat gebaut wurde', async () => {
+    const { withBasePath } = await importWithBasePath('/uat')
+    expect(withBasePath('/auth/callback')).toBe('/uat/auth/callback')
+  })
+
+  it('simuliert den Magic-Link-Redirect (emailRedirectTo) korrekt mit basePath', async () => {
+    // Reproduziert exakt die Zusammensetzung aus
+    // app/account/account-form.tsx, ohne einen echten Browser/Supabase-
+    // Projekt zu benötigen: `${window.location.origin}${withBasePath(...)}`.
+    const { withBasePath } = await importWithBasePath('/preview')
+    const origin = 'https://focus.lang-jamin.de'
+    const emailRedirectTo = `${origin}${withBasePath('/auth/callback')}`
+    expect(emailRedirectTo).toBe('https://focus.lang-jamin.de/preview/auth/callback')
+  })
+})

--- a/lib/base-path.ts
+++ b/lib/base-path.ts
@@ -1,0 +1,31 @@
+/**
+ * Der zur Build-Zeit konfigurierte `basePath` (siehe next.config.mjs,
+ * gesteuert über die Build-Zeit-Umgebungsvariable `NEXT_BASE_PATH`, z. B.
+ * `/preview` oder `/uat`).
+ *
+ * Next.js hängt den `basePath` automatisch an alle `<Link>`-Navigationen
+ * und an `redirect()`/`useRouter()` aus `next/navigation` an — dort ist
+ * nichts weiter zu tun. Das passiert NICHT automatisch bei von Hand
+ * zusammengesetzten absoluten URLs, zum Beispiel:
+ *
+ * - `${window.location.origin}/pfad` (z. B. Supabase `emailRedirectTo`)
+ * - `NextResponse.redirect(...)` in Route Handlern
+ * - eine direkte Zuweisung an `window.location.href = '/pfad'`
+ *
+ * Überall dort muss dieser Wert (bzw. `withBasePath`) explizit verwendet
+ * werden, sonst zeigt die gebaute URL unter `/preview/` oder `/uat/` auf
+ * den falschen (unpräfigierten) Pfad.
+ *
+ * Der Wert wird in next.config.mjs 1:1 in `NEXT_PUBLIC_BASE_PATH`
+ * gespiegelt, damit Server- und Client-Code garantiert denselben Wert wie
+ * die `basePath`-Konfiguration selbst sehen.
+ */
+export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || ''
+
+/**
+ * Baut einen absoluten Pfad inklusive `basePath`. `path` muss mit `/`
+ * beginnen, z. B. `withBasePath('/auth/callback')`.
+ */
+export function withBasePath(path: string): string {
+  return `${BASE_PATH}${path}`
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,26 @@
+// `basePath` wird von Next.js zur BUILD-Zeit ausgelesen und kann zur
+// Laufzeit nicht mehr variieren. Für zwei gleichzeitig laufende Instanzen
+// unter derselben Domain (`/preview/` und `/uat/`, siehe Issue #51 und
+// docs/PREVIEW-DEPLOYMENT.md) sind das folgerichtig zwei separate Builds:
+//
+//   NEXT_BASE_PATH=/preview npm run build   # eigener Prozess/Port
+//   NEXT_BASE_PATH=/uat     npm run build   # eigener Prozess/Port
+//
+// Ohne die Variable (z. B. lokal oder für einen späteren Produktions-
+// Cutover ohne Pfadpräfix) bleibt `basePath` leer wie bisher.
+const basePath = process.env.NEXT_BASE_PATH || ''
+
+// Next.js inlined `NEXT_PUBLIC_*`-Variablen zur Build-Zeit in den
+// Client-Bundle. Wir spiegeln den `basePath`-Wert hier explizit in eine
+// solche Variable, damit lib/base-path.ts denselben Wert sowohl im
+// Server- als auch im Client-Code liefert, ohne ihn doppelt pflegen zu
+// müssen.
+process.env.NEXT_PUBLIC_BASE_PATH = basePath
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  basePath,
 }
 
 export default nextConfig


### PR DESCRIPTION
Bezieht sich auf #51 (kein `Closes` — der VPS-/NGINX-Teil von #51 bleibt bei HERMES offen, dieser PR liefert nur den Repository-Anteil, den HERMES als Blocker gemeldet hat).

## Was geändert wurde

- `next.config.mjs`: `basePath` ist jetzt über die Build-Zeit-Umgebungsvariable `NEXT_BASE_PATH` konfigurierbar (z. B. `NEXT_BASE_PATH=/preview npm run build`). Ohne die Variable bleibt `basePath` leer — Standard-Build unverändert.
- `lib/base-path.ts` (neu): zentrale, getestete Konstante `BASE_PATH` / Helper `withBasePath()`, gespiegelt über `NEXT_PUBLIC_BASE_PATH` für Client- und Server-Code.
- Drei Stellen gefixt, die absolute URLs von Hand zusammenbauen und dadurch den `basePath` **nicht** automatisch bekommen hätten:
  - `app/account/account-form.tsx`: Supabase `emailRedirectTo` (`${window.location.origin}/auth/callback`)
  - `app/auth/callback/route.ts`: `NextResponse.redirect(...)` auf `/account` bzw. `/character`
  - `app/quest/first-light/quest-runner.tsx`: `window.location.href = '/camp'`
- `docs/PREVIEW-DEPLOYMENT.md`: Plesk-Abschnitt korrigiert (HERMES hat auf dem echten Ionos-VPS kein Plesk vorgefunden, tatsächlicher Weg ist Ubuntu 24.04 + Node.js 22 + NGINX direkt — Plesk-Abschnitt bleibt als Referenz stehen), konkretes Preview/UAT-Pfadmuster ergänzt (zwei Builds, zwei Prozesse/Ports, NGINX-`location`-Blöcke ohne Rewriting, systemd-Beispiel), beide Supabase-Redirect-URLs ergänzt.

## Der eigentliche Bug

`redirect()`/`useRouter()` aus `next/navigation` und `<Link>` hängen den konfigurierten `basePath` automatisch an — das ist in den vier Server-Components (`app/camp/page.tsx`, `app/character/page.tsx`, `app/adventure-book/page.tsx`, `app/quest/first-light/page.tsx`) verifiziert, dort war nichts zu ändern.

Was **nicht** automatisch funktioniert: von Hand aus `window.location.origin`/`url.origin` + literalem Pfad zusammengesetzte absolute URLs. Ohne diesen Fix hätte der Supabase-Magic-Link unter `basePath=/preview` auf `https://focus.lang-jamin.de/auth/callback` statt `https://focus.lang-jamin.de/preview/auth/callback` gezeigt — der Login in der Preview wäre kaputt gewesen, ohne dass Next.js, TypeScript oder ein oberflächlicher Test das gezeigt hätten.

## Wie HERMES das Ergebnis nutzen soll

1. Zwei Builds fahren: `NEXT_BASE_PATH=/preview npm run build` und `NEXT_BASE_PATH=/uat npm run build`, jeweils als eigener Checkout/Prozess/Port (konkretes Muster inkl. systemd- und NGINX-Beispiel in `docs/PREVIEW-DEPLOYMENT.md`, Abschnitt "Ionos VPS: Ubuntu 24.04 + Node.js 22 + NGINX, ohne Plesk").
2. NGINX-`location /preview/` und `location /uat/` jeweils per `proxy_pass` an den passenden Port — **ohne** Pfad-Rewrite, weil der Build den `basePath` bereits selbst rendert.
3. Beide Redirect-URLs in Supabase eintragen: `https://focus.lang-jamin.de/preview/auth/callback` und `https://focus.lang-jamin.de/uat/auth/callback`.
4. Danach den Magic-Link-Login auf beiden Pfaden real im Browser testen (das kann dieser PR ohne echtes Supabase-Projekt nicht abschließend verifizieren — lokal wurde der zusammengesetzte Redirect-String getestet, siehe unten).

## Verifikation

```bash
npm ci
npm run lint        # grün (2 vorbestehende Warnungen in eslint.config.mjs/postcss.config.mjs, unverändert)
npm run typecheck   # grün
npm test            # 108/108 grün, inkl. 4 neuer Tests für lib/base-path.ts
npm run build                          # Standard-Build ohne basePath, unverändert erfolgreich
NEXT_BASE_PATH=/preview npm run build  # erfolgreich
```

Zusätzlich lokal beide `basePath`-Builds (`/preview`, `/uat`) auf getrennten Ports mit `next start` gestartet und per `curl` geprüft: HTML und `/_next`-Asset-Pfade sind korrekt mit `/preview/` bzw. `/uat/` präfigiert, unpräfigierte Root-Pfade liefern 404 (Beweis, dass die Isolation tatsächlich greift, nicht nur kosmetisch aussieht).

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (108/108, inkl. neuer `lib/__tests__/base-path.test.ts`)
- [x] `npm run build` (ohne basePath)
- [x] `NEXT_BASE_PATH=/preview npm run build`
- [x] `NEXT_BASE_PATH=/uat npm run build`
- [x] Beide Builds lokal per `next start` auf getrennten Ports gestartet, `curl`-verifiziert (HTML, `/_next`-Assets, interne Seiten unter dem jeweiligen `basePath`)
- [ ] Echter Magic-Link-Login im Browser gegen Supabase (braucht die VPS-/NGINX-Einrichtung durch HERMES, siehe oben)

🤖 Generated with [Claude Code](https://claude.com/claude-code)