### PR TITLE
#junDev feat: M4 Abenteuerbuch mit 15/25/50-Minuten-Questkatalog

### DIFF
--- a/app/adventure-book/adventure-book.module.css
+++ b/app/adventure-book/adventure-book.module.css
@@ -7,146 +7,33 @@
   color: var(--text);
 }
 
-.book {
-  width: min(1120px, 100%);
-  margin: 0 auto;
-}
-
-.heading {
-  width: min(720px, 100%);
-  margin-bottom: clamp(28px, 5vw, 52px);
-}
-
-.heading h1 {
-  margin: 8px 0 14px;
-  font-size: clamp(2.25rem, 6vw, 4.8rem);
-  line-height: .98;
-}
-
-.heading p:last-child {
-  max-width: 58ch;
-  margin: 0;
-  color: var(--text-muted);
-  font-size: clamp(1rem, 2vw, 1.15rem);
-  line-height: 1.6;
-}
-
-.quest {
-  display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(320px, .85fr);
-  min-height: 520px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  background: var(--surface);
-}
-
-.questArt {
-  min-height: 420px;
-  background: #101713;
-}
-
-.questArt svg {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.questCopy {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: clamp(28px, 5vw, 58px);
-}
-
-.meta {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 20px;
-  margin-bottom: 18px;
-  color: var(--text-muted);
-  font-size: .95rem;
-}
-
-.meta strong {
-  color: var(--accent);
-  font-size: clamp(1.35rem, 3vw, 2rem);
-  font-variant-numeric: tabular-nums;
-}
-
-.questCopy h2 {
-  margin: 0 0 18px;
-  font-size: clamp(2rem, 4vw, 3.4rem);
-  line-height: 1.02;
-}
-
-.questCopy p {
-  margin: 0 0 14px;
-  color: var(--text-muted);
-  line-height: 1.6;
-}
-
-.departure {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  align-self: flex-start;
-  margin-top: 18px;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--accent);
-  color: var(--text);
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.departure span {
-  transition: transform 160ms ease-out;
-}
-
-.departure:hover span {
-  transform: translateX(4px);
-}
-
-.departure:focus-visible,
-.back:focus-visible {
-  outline: 3px solid var(--accent);
-  outline-offset: 6px;
-}
-
-.back {
-  display: inline-block;
-  margin-top: 24px;
-  color: var(--text-muted);
-  text-decoration: none;
-}
+.book { width: min(1120px, 100%); margin: 0 auto; }
+.heading { width: min(760px, 100%); margin-bottom: clamp(28px, 5vw, 52px); }
+.heading h1 { margin: 8px 0 14px; font-size: clamp(2.25rem, 6vw, 4.8rem); line-height: .98; }
+.heading p:last-child { max-width: 60ch; margin: 0; color: var(--text-muted); font-size: clamp(1rem, 2vw, 1.15rem); line-height: 1.6; }
+.catalog { display: grid; gap: clamp(20px, 3vw, 34px); }
+.quest { display: grid; grid-template-columns: minmax(0, .8fr) minmax(320px, 1.2fr); min-height: 360px; overflow: hidden; border: 1px solid var(--border); background: var(--surface); }
+.questArt { min-height: 320px; background: #101713; }
+.questArt svg { display: block; width: 100%; height: 100%; }
+.questCopy { display: flex; flex-direction: column; justify-content: center; padding: clamp(26px, 4vw, 48px); }
+.meta { display: flex; align-items: baseline; justify-content: space-between; gap: 20px; margin-bottom: 18px; color: var(--text-muted); font-size: .95rem; }
+.meta strong { color: var(--accent); font-size: clamp(1.25rem, 2.5vw, 1.8rem); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.questCopy h2 { margin: 0 0 18px; font-size: clamp(1.8rem, 3.5vw, 3rem); line-height: 1.05; }
+.questCopy p { margin: 0 0 12px; color: var(--text-muted); line-height: 1.6; }
+.departure { display: inline-flex; align-items: center; gap: 10px; align-self: flex-start; margin-top: 14px; padding: 10px 0; border-bottom: 1px solid var(--accent); color: var(--text); font-weight: 700; text-decoration: none; }
+.departure span { transition: transform 160ms ease-out; }
+.departure:hover span { transform: translateX(4px); }
+.departure:focus-visible, .back:focus-visible { outline: 3px solid var(--accent); outline-offset: 6px; }
+.back { display: inline-block; margin-top: 28px; color: var(--text-muted); text-decoration: none; }
 
 @media (max-width: 780px) {
-  .shell {
-    padding: 24px 18px 36px;
-  }
-
-  .quest {
-    grid-template-columns: 1fr;
-  }
-
-  .questArt {
-    min-height: 260px;
-  }
-
-  .meta {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 6px;
-  }
+  .shell { padding: 24px 18px 36px; }
+  .quest { grid-template-columns: 1fr; }
+  .questArt { min-height: 220px; }
+  .meta { align-items: flex-start; flex-direction: column; gap: 6px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .departure span {
-    transition: none;
-  }
-
-  .departure:hover span {
-    transform: none;
-  }
+  .departure span { transition: none; }
+  .departure:hover span { transform: none; }
 }

--- a/app/adventure-book/page.tsx
+++ b/app/adventure-book/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { QUEST_CATALOG } from '../../lib/quests/catalog'
 import { withBasePath } from '../../lib/base-path'
 import { createSupabaseServerClient } from '../../lib/supabase/server'
 import styles from './adventure-book.module.css'
@@ -27,38 +28,37 @@ export default async function AdventureBookPage() {
       <section className={styles.book} aria-labelledby="book-title">
         <div className={styles.heading}>
           <p className="eyebrow">Abenteuerbuch</p>
-          <h1 id="book-title">Heute wartet nur ein Weg.</h1>
+          <h1 id="book-title">Welcher Weg passt heute zu dir?</h1>
           <p>
-            Kein Stapel voller Pflichten. Nur eine kleine Spur im Unterholz, die für fünfzehn ruhige Minuten deine
-            Aufmerksamkeit gebrauchen könnte.
+            Sechs kleine Wege liegen offen. Manche sind kurz, andere brauchen etwas mehr Wald — keiner davon hat es eilig.
           </p>
         </div>
 
-        <article className={styles.quest} aria-labelledby="quest-title">
-          <div className={styles.questArt} aria-hidden="true">
-            <svg viewBox="0 0 1600 900" focusable="false">
-              <use href={withBasePath('/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-01')} />
-            </svg>
-          </div>
+        <div className={styles.catalog} aria-label="Verfügbare Quests">
+          {QUEST_CATALOG.map((quest, index) => (
+            <article className={styles.quest} aria-labelledby={`quest-title-${quest.key}`} key={quest.key}>
+              <div className={styles.questArt} aria-hidden="true">
+                <svg viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" focusable="false">
+                  <use href={withBasePath(`/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-0${(index % 4) + 1}`)} />
+                </svg>
+              </div>
 
-          <div className={styles.questCopy}>
-            <div className={styles.meta}>
-              <span>Erste Quest</span>
-              <strong>15 Minuten</strong>
-            </div>
-            <h2 id="quest-title">Ein Licht im Unterholz</h2>
-            <p>
-              Zwischen Farnen flackert ein schwaches Licht. Folge ihm ein Stück und widme dich dabei genau einer Sache,
-              die heute wirklich weiterkommen soll.
-            </p>
-            <p>Du musst nichts beweisen. Fünfzehn Minuten reichen für diesen Abschnitt des Weges.</p>
+              <div className={styles.questCopy}>
+                <div className={styles.meta}>
+                  <span>{quest.region} · {quest.location}</span>
+                  <strong>{quest.durationMinutes} Minuten</strong>
+                </div>
+                <h2 id={`quest-title-${quest.key}`}>{quest.title}</h2>
+                {quest.assignment.map((paragraph) => paragraph ? <p key={paragraph}>{paragraph}</p> : null)}
 
-            <Link className={styles.departure} href="/quest/first-light">
-              Zum Aufbruch
-              <span aria-hidden="true">→</span>
-            </Link>
-          </div>
-        </article>
+                <Link className={styles.departure} href={quest.href}>
+                  Diesen Weg wählen
+                  <span aria-hidden="true">→</span>
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
 
         <Link className={styles.back} href="/camp">
           Zurück ans Feuer

--- a/app/quest/catalog/[questKey]/page.tsx
+++ b/app/quest/catalog/[questKey]/page.tsx
@@ -1,0 +1,42 @@
+import { notFound, redirect } from 'next/navigation'
+import { createSupabaseServerClient } from '../../../../lib/supabase/server'
+import { FocusSessionRow } from '../../../../lib/timer/first-light'
+import { getQuestByKey } from '../../../../lib/quests/catalog'
+import { CatalogQuestRunner } from './quest-runner'
+
+export const dynamic = 'force-dynamic'
+
+const FOCUS_SESSION_COLUMNS =
+  'id, status, started_at, duration_seconds, accumulated_ms, paused_at, completed_at, rewarded_at, rest_finished_at, chest_opened_at'
+
+export default async function CatalogQuestPage({ params }: { params: Promise<{ questKey: string }> }) {
+  const { questKey } = await params
+  const quest = getQuestByKey(questKey)
+  if (!quest || quest.key === 'ein-licht-im-unterholz') notFound()
+
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) redirect('/account')
+
+  const { data: character } = await supabase
+    .from('characters')
+    .select('name')
+    .eq('profile_id', user.id)
+    .maybeSingle()
+
+  if (!character) redirect('/character')
+
+  const { data: session } = await supabase
+    .from('focus_sessions')
+    .select(FOCUS_SESSION_COLUMNS)
+    .eq('profile_id', user.id)
+    .eq('quest_key', quest.key)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle<FocusSessionRow>()
+
+  return <CatalogQuestRunner quest={quest} initialSession={session ?? null} />
+}

--- a/app/quest/catalog/[questKey]/quest-runner.tsx
+++ b/app/quest/catalog/[questKey]/quest-runner.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createSupabaseBrowserClient } from '../../../../lib/supabase/client'
+import { useReducedMotion } from '../../../../lib/hooks/use-reduced-motion'
+import { FocusSessionRow, toTimerSession } from '../../../../lib/timer/first-light'
+import { formatRemaining, snapshot } from '../../../../lib/timer/session'
+import { layerOffset } from '../../../../lib/timer/journey'
+import { QuestDefinition } from '../../../../lib/quests/catalog'
+import { withBasePath } from '../../../../lib/base-path'
+import styles from '../../first-light/first-light.module.css'
+
+type SupabaseClient = ReturnType<typeof createSupabaseBrowserClient>
+type Stage = 'briefing' | 'departure' | 'focus' | 'resolution'
+
+async function callRpc<T>(
+  client: SupabaseClient,
+  fn: string,
+  args?: Record<string, unknown>,
+): Promise<{ data: T | null; error: { message: string } | null }> {
+  const result = await client.rpc(fn, args ?? {})
+  return result as unknown as { data: T | null; error: { message: string } | null }
+}
+
+export function CatalogQuestRunner({ quest, initialSession }: { quest: QuestDefinition; initialSession: FocusSessionRow | null }) {
+  const supabase = useMemo(() => createSupabaseBrowserClient(), [])
+  const reducedMotion = useReducedMotion()
+  const [session, setSession] = useState(initialSession)
+  const [departing, setDeparting] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
+  const [error, setError] = useState<string | null>(null)
+  const [liveMessage, setLiveMessage] = useState('')
+  const completingRef = useRef(false)
+
+  const stage: Stage = departing
+    ? 'departure'
+    : !session || session.status === 'cancelled'
+      ? 'briefing'
+      : session.status === 'active'
+        ? 'focus'
+        : 'resolution'
+
+  useEffect(() => {
+    if (stage !== 'focus') return
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [stage])
+
+  const focusSnapshot = useMemo(() => {
+    if (!session || session.status !== 'active') return null
+    return snapshot(toTimerSession(session), now)
+  }, [session, now])
+
+  const completeSession = useCallback(async () => {
+    if (!session || completingRef.current) return
+    completingRef.current = true
+    const { data, error: rpcError } = await callRpc<FocusSessionRow>(supabase, 'complete_catalog_quest_session', {
+      p_session_id: session.id,
+    })
+    completingRef.current = false
+    if (rpcError || !data) {
+      setError('Der Weg konnte noch nicht abgeschlossen werden. Bitte versuch es gleich noch einmal.')
+      return
+    }
+    setSession(data)
+  }, [session, supabase])
+
+  useEffect(() => {
+    if (focusSnapshot?.is_complete) void completeSession()
+  }, [focusSnapshot?.is_complete, completeSession])
+
+  useEffect(() => {
+    if (stage === 'departure') setLiveMessage('Du brichst auf.')
+    if (stage === 'focus') setLiveMessage(`Fokus beginnt. ${quest.durationMinutes} Minuten Weg liegen vor dir.`)
+    if (stage === 'resolution') setLiveMessage('Die Quest ist abgeschlossen.')
+  }, [stage, quest.durationMinutes])
+
+  async function startDeparture() {
+    setError(null)
+    setDeparting(true)
+    const { data, error: rpcError } = await callRpc<FocusSessionRow>(supabase, 'start_catalog_quest_session', {
+      p_quest_key: quest.key,
+      p_duration_seconds: quest.durationMinutes * 60,
+    })
+    if (rpcError || !data) {
+      setDeparting(false)
+      setError('Der Aufbruch ist gerade nicht möglich. Vielleicht ist noch ein anderer Weg offen.')
+      return
+    }
+    window.setTimeout(() => {
+      setSession(data)
+      setDeparting(false)
+    }, 3000)
+  }
+
+  async function togglePause() {
+    if (!session) return
+    const rpcName = focusSnapshot?.is_paused ? 'resume_focus_session' : 'pause_focus_session'
+    const { data, error: rpcError } = await callRpc<FocusSessionRow>(supabase, rpcName, { p_session_id: session.id })
+    if (!rpcError && data) setSession(data)
+  }
+
+  async function leaveQuest() {
+    if (!session) return
+    await callRpc(supabase, 'cancel_focus_session', { p_session_id: session.id })
+    window.location.href = withBasePath('/adventure-book')
+  }
+
+  const beat = focusSnapshot ? Math.min(3, Math.floor(focusSnapshot.progress * 4)) : 0
+  const silhouetteX = focusSnapshot && !reducedMotion ? layerOffset(focusSnapshot.progress, 120, 1) : 0
+
+  return (
+    <main id="main-content" className={styles.shell} data-stage={stage}>
+      <div role="status" aria-live="polite" className={styles.visuallyHidden}>{liveMessage}</div>
+      {error ? <p role="alert" className={styles.error}>{error}</p> : null}
+
+      {stage === 'briefing' ? (
+        <section className={styles.card} aria-labelledby="catalog-briefing-title">
+          <p className="eyebrow">{quest.region} · {quest.location}</p>
+          <h1 id="catalog-briefing-title">{quest.title}</h1>
+          {quest.assignment.map((paragraph) => paragraph ? <p key={paragraph}>{paragraph}</p> : null)}
+          <p>{quest.durationMinutes} Minuten Weg.</p>
+          <button type="button" onClick={startDeparture}>Aufbrechen</button>
+        </section>
+      ) : null}
+
+      {stage === 'departure' ? (
+        <section className={styles.departure} aria-labelledby="catalog-departure-title">
+          <svg viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" aria-hidden="true" focusable="false" className={styles.departureArt}>
+            <use href={withBasePath('/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-01')} />
+          </svg>
+          <div className={styles.departureCopy}>
+            <p className="eyebrow">Aufbruch</p>
+            <h1 id="catalog-departure-title">Du machst dich auf den Weg.</h1>
+          </div>
+        </section>
+      ) : null}
+
+      {stage === 'focus' && focusSnapshot ? (
+        <section className={styles.focusStage} aria-labelledby="catalog-focus-title">
+          <div className={styles.beatLayer} aria-hidden="true">
+            {Array.from({ length: 4 }, (_, index) => (
+              <svg key={index} viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" focusable="false" className={styles.beat} data-active={index === beat}>
+                <use href={withBasePath(`/assets/phase1-art-pack.svg#quest-light-undergrowth-beat-0${index + 1}`)} />
+              </svg>
+            ))}
+          </div>
+          <svg viewBox="0 0 220 260" aria-hidden="true" focusable="false" className={styles.silhouette} style={{ transform: `translateX(${silhouetteX}px)` }}>
+            <use href={withBasePath('/assets/phase1-art-pack.svg#journey-silhouette')} />
+          </svg>
+          <div className={styles.timerPanel}>
+            <p className="eyebrow" id="catalog-focus-title">{quest.title}</p>
+            <p className={styles.timer} aria-hidden="true">{formatRemaining(focusSnapshot.remaining_ms)}</p>
+            <div className={styles.controls}>
+              <button type="button" onClick={togglePause}>{focusSnapshot.is_paused ? 'Weiter' : 'Pause'}</button>
+              <button type="button" className={styles.leave} onClick={leaveQuest}>Quest verlassen</button>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {stage === 'resolution' ? (
+        <section className={styles.card} aria-labelledby="catalog-resolution-title">
+          <p className="eyebrow">Questabschluss</p>
+          <h1 id="catalog-resolution-title">Dieser Weg ist geschafft.</h1>
+          <p>Du kannst den Gedanken hier ablegen. Der Wald merkt sich keine offenen Tabs.</p>
+          <Link href="/adventure-book">Zurück zum Abenteuerbuch</Link>
+        </section>
+      ) : null}
+    </main>
+  )
+}

--- a/lib/quests/catalog.test.ts
+++ b/lib/quests/catalog.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { getQuestByKey, QUEST_CATALOG } from './catalog'
+
+describe('QUEST_CATALOG', () => {
+  it('contains exactly two quests for each supported duration', () => {
+    expect(QUEST_CATALOG).toHaveLength(6)
+    expect(QUEST_CATALOG.filter((quest) => quest.durationMinutes === 15)).toHaveLength(2)
+    expect(QUEST_CATALOG.filter((quest) => quest.durationMinutes === 25)).toHaveLength(2)
+    expect(QUEST_CATALOG.filter((quest) => quest.durationMinutes === 50)).toHaveLength(2)
+  })
+
+  it('keeps stable unique keys and the phase-1 quest', () => {
+    expect(new Set(QUEST_CATALOG.map((quest) => quest.key)).size).toBe(6)
+    expect(getQuestByKey('ein-licht-im-unterholz')?.durationMinutes).toBe(15)
+  })
+
+  it('keeps all catalog data required by the adventure book and journey', () => {
+    for (const quest of QUEST_CATALOG) {
+      expect(quest.title.length).toBeGreaterThan(0)
+      expect(quest.assignment[0].length).toBeGreaterThan(0)
+      expect(quest.region.length).toBeGreaterThan(0)
+      expect(quest.location.length).toBeGreaterThan(0)
+      expect(quest.journeyRef).toBe('unterholz')
+      expect(quest.href.startsWith('/quest/')).toBe(true)
+    }
+  })
+})

--- a/lib/quests/catalog.ts
+++ b/lib/quests/catalog.ts
@@ -1,0 +1,97 @@
+export type QuestDurationMinutes = 15 | 25 | 50
+
+export interface QuestDefinition {
+  key: string
+  title: string
+  durationMinutes: QuestDurationMinutes
+  assignment: readonly [string, string?]
+  region: string
+  location: string
+  journeyRef: 'unterholz'
+  href: string
+}
+
+export const QUEST_CATALOG: readonly QuestDefinition[] = [
+  {
+    key: 'ein-licht-im-unterholz',
+    title: 'Ein Licht im Unterholz',
+    durationMinutes: 15,
+    assignment: [
+      'Zwischen Farnen flackert ein schwaches Licht. Folge ihm ein Stück und widme dich dabei genau einer Sache, die heute wirklich weiterkommen soll.',
+      'Du musst nichts beweisen. Fünfzehn Minuten reichen für diesen Abschnitt des Weges.',
+    ],
+    region: 'Flüsterwald',
+    location: 'Unterholzpfad',
+    journeyRef: 'unterholz',
+    href: '/quest/first-light',
+  },
+  {
+    key: 'moos-am-alten-steg',
+    title: 'Moos am alten Steg',
+    durationMinutes: 15,
+    assignment: [
+      'Am alten Steg sammelt sich Morgenfeuchte im Moos. Nimm dir einen kleinen Arbeitsabschnitt vor und bleib bei ihm, bis der Weg ein Stück klarer ist.',
+      'Der Steg hält auch ohne Eile.',
+    ],
+    region: 'Flüsterwald',
+    location: 'Alter Steg',
+    journeyRef: 'unterholz',
+    href: '/quest/catalog/moos-am-alten-steg',
+  },
+  {
+    key: 'kartenrand-im-farn',
+    title: 'Der Kartenrand im Farn',
+    durationMinutes: 25,
+    assignment: [
+      'Ein Stück einer alten Karte schaut zwischen den Farnen hervor. Nutze diesen Weg, um eine Sache konzentriert weiterzuführen, die etwas mehr Ruhe braucht.',
+      'Fünfundzwanzig Minuten sind genug, um eine Spur aufzunehmen.',
+    ],
+    region: 'Flüsterwald',
+    location: 'Farnsenke',
+    journeyRef: 'unterholz',
+    href: '/quest/catalog/kartenrand-im-farn',
+  },
+  {
+    key: 'teehaus-hinter-den-birken',
+    title: 'Das Teehaus hinter den Birken',
+    durationMinutes: 25,
+    assignment: [
+      'Hinter den Birken steht ein kleines Teehaus, dessen Fenster schon lange niemand geöffnet hat. Arbeite an genau einer Aufgabe weiter, während du den Weg dorthin suchst.',
+      'Der Tee läuft nicht weg. Sehr wahrscheinlich.',
+    ],
+    region: 'Flüsterwald',
+    location: 'Birkenhain',
+    journeyRef: 'unterholz',
+    href: '/quest/catalog/teehaus-hinter-den-birken',
+  },
+  {
+    key: 'pfad-der-stillen-steine',
+    title: 'Der Pfad der stillen Steine',
+    durationMinutes: 50,
+    assignment: [
+      'Runde Wegsteine führen tiefer in den Wald, einer nach dem anderen. Nimm eine größere Aufgabe mit und gib ihr für diesen Abschnitt deine ungeteilte Aufmerksamkeit.',
+      'Fünfzig Minuten dürfen sich lang anfühlen. Der Pfad erwartet nichts weiter.',
+    ],
+    region: 'Flüsterwald',
+    location: 'Steinpfad',
+    journeyRef: 'unterholz',
+    href: '/quest/catalog/pfad-der-stillen-steine',
+  },
+  {
+    key: 'laternen-am-waldrand',
+    title: 'Laternen am Waldrand',
+    durationMinutes: 50,
+    assignment: [
+      'Am Waldrand hängen alte Laternen zwischen niedrigen Ästen und markieren einen ruhigen, langen Weg. Nimm dir ein Vorhaben vor, das heute wirklich Raum bekommen soll.',
+      'Du musst nicht schneller gehen. Nur beim Weg bleiben.',
+    ],
+    region: 'Flüsterwald',
+    location: 'Nördlicher Waldrand',
+    journeyRef: 'unterholz',
+    href: '/quest/catalog/laternen-am-waldrand',
+  },
+] as const
+
+export function getQuestByKey(key: string): QuestDefinition | null {
+  return QUEST_CATALOG.find((quest) => quest.key === key) ?? null
+}

--- a/supabase/migrations/20260906214000_catalog_quest_sessions.sql
+++ b/supabase/migrations/20260906214000_catalog_quest_sessions.sql
@@ -1,0 +1,91 @@
+-- M4 #26: server-authoritative 15/25/50 minute catalog sessions.
+-- Keeps focus_sessions as the single source of truth for elapsed time.
+
+create or replace function public.start_catalog_quest_session(
+  p_quest_key text,
+  p_duration_seconds integer
+)
+returns public.focus_sessions
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_session public.focus_sessions%rowtype;
+begin
+  if v_user_id is null then raise exception 'authentication required'; end if;
+
+  if (p_quest_key, p_duration_seconds) not in (
+    ('moos-am-alten-steg', 900),
+    ('kartenrand-im-farn', 1500),
+    ('teehaus-hinter-den-birken', 1500),
+    ('pfad-der-stillen-steine', 3000),
+    ('laternen-am-waldrand', 3000)
+  ) then
+    raise exception 'unknown catalog quest or duration';
+  end if;
+
+  insert into public.focus_sessions(profile_id, quest_key, started_at, duration_seconds, status)
+  values (v_user_id, p_quest_key, now(), p_duration_seconds, 'active')
+  on conflict (profile_id) where status = 'active' do nothing;
+
+  select * into v_session
+  from public.focus_sessions fs
+  where fs.profile_id = v_user_id and fs.status = 'active'
+  order by fs.created_at desc
+  limit 1;
+
+  if v_session.quest_key <> p_quest_key or v_session.duration_seconds <> p_duration_seconds then
+    raise exception 'another focus session is already active';
+  end if;
+
+  return v_session;
+end;
+$$;
+
+create or replace function public.complete_catalog_quest_session(p_session_id uuid)
+returns public.focus_sessions
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_session public.focus_sessions%rowtype;
+  v_elapsed_ms bigint;
+begin
+  if v_user_id is null then raise exception 'authentication required'; end if;
+
+  select * into v_session
+  from public.focus_sessions fs
+  where fs.id = p_session_id and fs.profile_id = v_user_id
+  for update;
+
+  if not found then raise exception 'session not found'; end if;
+  if v_session.quest_key = 'ein-licht-im-unterholz' then raise exception 'phase 1 quest uses its existing completion flow'; end if;
+  if v_session.duration_seconds not in (900, 1500, 3000) then raise exception 'unsupported catalog duration'; end if;
+
+  if v_session.status = 'active' then
+    v_elapsed_ms := v_session.accumulated_ms;
+    if v_session.paused_at is null then
+      v_elapsed_ms := v_elapsed_ms + greatest(0, floor(extract(epoch from (now() - v_session.started_at)) * 1000))::bigint;
+    end if;
+    if v_elapsed_ms < v_session.duration_seconds::bigint * 1000 then raise exception 'focus duration not yet elapsed'; end if;
+
+    update public.focus_sessions fs
+    set status = 'completed', completed_at = now()
+    where fs.id = p_session_id
+    returning * into v_session;
+  elsif v_session.status <> 'completed' then
+    raise exception 'session is not completable';
+  end if;
+
+  return v_session;
+end;
+$$;
+
+revoke all on function public.start_catalog_quest_session(text, integer) from public;
+revoke all on function public.complete_catalog_quest_session(uuid) from public;
+grant execute on function public.start_catalog_quest_session(text, integer) to authenticated;
+grant execute on function public.complete_catalog_quest_session(uuid) to authenticated;


### PR DESCRIPTION
Umsetzung von #26 als erstes M4-/Phase-2-Developer-Paket.

Enthalten:
- zentraler datengetriebener Questkatalog mit genau 6 kuratierten Quests (2×15, 2×25, 2×50 Minuten)
- `Ein Licht im Unterholz` unverändert als Phase-1-Quest im Katalog und weiterhin über seinen bestehenden Legacy-/Reward-Flow erreichbar
- Titel, stabile Keys, Dauer, Auftrag, Region/Ort und Journey-Referenz zentral in `lib/quests/catalog.ts`
- Abenteuerbuch rendert ausschließlich aus diesem Katalog; Dauer bleibt Teil der Abenteuerwahl, keine generische Timer-Konfiguration
- fünf neue Katalogquests laufen über `focus_sessions`, `snapshot/toTimerSession`, bestehende Pause/Resume-RPCs und dieselbe Journey-/Parallax-Infrastruktur
- neue serverseitige RPCs `start_catalog_quest_session` / `complete_catalog_quest_session` validieren Quest+15/25/50-Dauer und bleiben serverzeit-autoritativ
- Reload lädt die aktive Session wieder aus `focus_sessions`; Hintergrund-Tabs berechnen Restzeit aus Server-Startzeit/accumulated_ms statt einer zweiten Countdown-Wahrheit
- responsive Abenteuerbuch-UX, Tastaturfokus und Reduced-Motion bleiben erhalten

Bewusst nicht enthalten: Loot-/Truhen-Ausbau, Inventar, Item-Baukasten, Händler, Party/Multiplayer, epische 3×25-Minuten-Abenteuer, englische Übersetzung.

Review-Reihenfolge nach grünem CI: Technical Owner (Session-/Timer-Wahrheit, Reload-Sicherheit) → Project Lead (Produkt/UX/Tonalität).

Closes #26