### PR TITLE
#SENDEV #art als vierten Hashtag in WORKFLOW.md integrieren

### DIFF
--- a/.github/workflows/title-labels.yml
+++ b/.github/workflows/title-labels.yml
@@ -22,7 +22,7 @@ jobs:
             if (!item) return;
 
             const title = item.title || "";
-            const known = ["#SENDEV", "#junDev", "#release"];
+            const known = ["#SENDEV", "#junDev", "#release", "#art"];
             const wanted = known.filter((tag) => title.includes(tag));
 
             if (wanted.length === 0) return;

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -14,10 +14,12 @@ Das ist keine Bürokratie, sondern eine Notwendigkeit: Dieses Projekt wird spät
 **anderen Team** übernommen und gehostet. Alles, was nur in einem Kopf existiert, geht bei
 der Übergabe verloren.
 
-## Die drei Hashtags
+## Die Hashtags
 
 Jedes Issue und jeder Pull Request trägt Hashtags im Titel. Sie sind gleichzeitig als
-GitHub-Labels gesetzt, damit man filtern kann.
+GitHub-Labels gesetzt, damit man filtern kann. `.github/workflows/title-labels.yml`
+setzt sie automatisch, sobald der Hashtag im Titel steht — ein Hashtag, der hier nicht
+gelistet ist, wird nicht automatisch gelabelt.
 
 ### `#SENDEV` — Senior Development
 
@@ -46,6 +48,23 @@ des Produkts:
 Jedes `#junDev`-Issue **muss** enthalten: Akzeptanzkriterien, betroffene Dateien und
 einen benannten Ansprechpartner für Rückfragen. Ein Issue, das diese drei Dinge nicht
 hat, ist noch kein `#junDev`-Issue.
+
+### `#art` — Art-/Audio-Produktion
+
+Kreative Bildgenerierung/-produktion, ausdrücklich **kein** Entwicklungsauftrag. Kein
+Developer ist für die kreative Produktion verantwortlich — die Rolle heißt hier
+"Art Agent", nicht Developer/Senior Developer. Beispiele:
+
+- Regionen-Kulissen, Key Visuals, Journey-Hintergründe
+- Truhen-/Item-Illustrationen, Charaktervarianten
+- Audio-Cues (Ambience, Motive, SFX)
+
+`#art`-Issues **müssen** enthalten: verbindliche Art Direction (Referenz auf
+`docs/ART-DIRECTION.md`), benötigte Assets/Formate, Konsistenzanforderungen zu
+bestehender Art, und eine explizite Freigabe-Instanz (i. d. R. Project Lead) vor der
+technischen Integration durch einen Developer in einem separaten Folgeauftrag.
+`#art` ersetzt `#junDev`/`#SENDEV` nicht dadurch, dass später jemand die Assets
+einbaut — die Integration selbst bekommt ihr eigenes `#junDev`/`#SENDEV`-Issue.
 
 ### `#release` — Freigabe durch das Release Team
 


### PR DESCRIPTION
## Problem
Issue #22 nutzt bereits \`#art\` im Titel (OpenAI-Art-Agent-Konzept für Regionen-Kulissen), aber der Hashtag stand weder in \`docs/WORKFLOW.md\` noch im Auto-Labeler (\`title-labels.yml\`) — er wurde deshalb nie als echtes Label gesetzt. Verstößt gegen die eigene Regel "Hashtag im Titel = Label".

## Änderungen
- \`docs/WORKFLOW.md\`: \`#art\` als vierte Kategorie dokumentiert — kreative Produktion, kein Entwicklungsauftrag, eigene Freigabe-Instanz (i. d. R. Project Lead) vor technischer Integration durch einen Developer in einem separaten Folgeauftrag.
- \`title-labels.yml\`: \`#art\` zur erkannten Liste ergänzt.
- Label \`#art\` im Repo angelegt und auf #22 nachgetragen (passend zum Titel).

Kein App-Code verändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)