### PR TITLE
#SENDEV fix: correct live auth callback origin for preview and uat

### DIFF
--- a/app/account/account-form.tsx
+++ b/app/account/account-form.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { FormEvent, useEffect, useState } from 'react'
+import { getAuthCallbackUrl } from '../../lib/auth-redirect'
 import { createSupabaseBrowserClient } from '../../lib/supabase/client'
-import { withBasePath } from '../../lib/base-path'
 
 type Status = 'idle' | 'loading' | 'sent' | 'offline' | 'error'
 
@@ -46,7 +46,7 @@ export function AccountForm({ expired }: { expired: boolean }) {
       const supabase = createSupabaseBrowserClient()
       const { error } = await supabase.auth.signInWithOtp({
         email,
-        options: { emailRedirectTo: `${window.location.origin}${withBasePath('/auth/callback')}` },
+        options: { emailRedirectTo: getAuthCallbackUrl(window.location.origin) },
       })
 
       if (error) throw error

--- a/app/adventure-book/page.tsx
+++ b/app/adventure-book/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { createSupabaseServerClient } from '../../lib/supabase/server'
 import { withBasePath } from '../../lib/base-path'
+import { createSupabaseServerClient } from '../../lib/supabase/server'
 import styles from './adventure-book.module.css'
 
 export const dynamic = 'force-dynamic'

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,14 +1,15 @@
 import { NextResponse } from 'next/server'
+import { getAccountExpiredUrl, getCharacterUrl } from '../../../lib/auth-redirect'
+import { getAuthRequestOrigin } from '../../../lib/auth-request-origin'
 import { createSupabaseServerClient } from '../../../lib/supabase/server'
-import { withBasePath } from '../../../lib/base-path'
 
 export async function GET(request: Request) {
   const url = new URL(request.url)
   const code = url.searchParams.get('code')
-  const origin = url.origin
+  const origin = getAuthRequestOrigin(request)
 
   if (!code) {
-    return NextResponse.redirect(`${origin}${withBasePath('/account?error=expired')}`)
+    return NextResponse.redirect(getAccountExpiredUrl(origin))
   }
 
   try {
@@ -16,11 +17,11 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
 
     if (error) {
-      return NextResponse.redirect(`${origin}${withBasePath('/account?error=expired')}`)
+      return NextResponse.redirect(getAccountExpiredUrl(origin))
     }
 
-    return NextResponse.redirect(`${origin}${withBasePath('/character')}`)
+    return NextResponse.redirect(getCharacterUrl(origin))
   } catch {
-    return NextResponse.redirect(`${origin}${withBasePath('/account?error=expired')}`)
+    return NextResponse.redirect(getAccountExpiredUrl(origin))
   }
 }

--- a/app/camp/page.tsx
+++ b/app/camp/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { createSupabaseServerClient } from '../../lib/supabase/server'
 import { withBasePath } from '../../lib/base-path'
+import { createSupabaseServerClient } from '../../lib/supabase/server'
 import styles from './camp.module.css'
 
 export const dynamic = 'force-dynamic'

--- a/app/character/character-creator.tsx
+++ b/app/character/character-creator.tsx
@@ -2,8 +2,8 @@
 
 import { FormEvent, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { createSupabaseBrowserClient } from '../../lib/supabase/client'
 import { withBasePath } from '../../lib/base-path'
+import { createSupabaseBrowserClient } from '../../lib/supabase/client'
 import styles from './character.module.css'
 
 const ancestries = [

--- a/app/quest/first-light/quest-runner.tsx
+++ b/app/quest/first-light/quest-runner.tsx
@@ -2,13 +2,13 @@
 
 import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { withBasePath } from '../../../lib/base-path'
 import { createSupabaseBrowserClient } from '../../../lib/supabase/client'
 import { useSceneAudio } from '../../../lib/audio/use-scene-audio'
 import { useReducedMotion } from '../../../lib/hooks/use-reduced-motion'
 import { deriveQuestPhase, FocusSessionRow, toRestSession, toTimerSession } from '../../../lib/timer/first-light'
 import { formatRemaining, snapshot } from '../../../lib/timer/session'
 import { layerOffset } from '../../../lib/timer/journey'
-import { withBasePath } from '../../../lib/base-path'
 import styles from './first-light.module.css'
 
 type SupabaseClient = ReturnType<typeof createSupabaseBrowserClient>
@@ -32,11 +32,11 @@ async function callRpc<T>(
 
 const BEAT_COUNT = 4
 const AUDIO = {
-  departure: '/audio/audio-departure-motif-01.ogg',
-  focus: '/audio/audio-focus-light-undergrowth-01.ogg',
-  resolve: '/audio/audio-completion-resolve-01.ogg',
-  rest: '/audio/audio-rest-campfire-ambience-01.ogg',
-  chest: '/audio/sfx-chest-lantern-material-01.ogg',
+  departure: withBasePath('/audio/audio-departure-motif-01.ogg'),
+  focus: withBasePath('/audio/audio-focus-light-undergrowth-01.ogg'),
+  resolve: withBasePath('/audio/audio-completion-resolve-01.ogg'),
+  rest: withBasePath('/audio/audio-rest-campfire-ambience-01.ogg'),
+  chest: withBasePath('/audio/sfx-chest-lantern-material-01.ogg'),
 } as const
 
 type Stage = 'briefing' | 'departure' | 'focus' | 'resolution' | 'resting' | 'chest' | 'done'

--- a/lib/__tests__/auth-redirect.test.ts
+++ b/lib/__tests__/auth-redirect.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Gleicher Grund wie in auth-request-origin.test.ts: withBasePath()s BASE_PATH
+// wird beim Modul-Import einmalig ausgewertet, vi.stubEnv() danach wirkt sich
+// darauf nicht mehr aus. Modul nach jeder Env-Änderung frisch importieren.
+async function importWithBasePath(basePath: string) {
+  vi.resetModules()
+  process.env.NEXT_PUBLIC_BASE_PATH = basePath
+  return import('../auth-redirect')
+}
+
+describe('auth redirect URLs', () => {
+  const original = process.env.NEXT_PUBLIC_BASE_PATH
+
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.NEXT_PUBLIC_BASE_PATH
+    else process.env.NEXT_PUBLIC_BASE_PATH = original
+    vi.resetModules()
+  })
+
+  it.each(['/preview', '/uat'])('keeps magic-link and callback redirects under %s', async (basePath) => {
+    const { getAuthCallbackUrl, getAccountExpiredUrl, getCharacterUrl } = await importWithBasePath(basePath)
+
+    expect(getAuthCallbackUrl('https://example.test')).toBe(`https://example.test${basePath}/auth/callback`)
+    expect(getAccountExpiredUrl('https://example.test')).toBe(
+      `https://example.test${basePath}/account?error=expired`,
+    )
+    expect(getCharacterUrl('https://example.test')).toBe(`https://example.test${basePath}/character`)
+  })
+})

--- a/lib/__tests__/auth-request-origin.test.ts
+++ b/lib/__tests__/auth-request-origin.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `getAccountExpiredUrl`/`getCharacterUrl` gehen über `lib/auth-redirect.ts` auf
+// `withBasePath()`, dessen `BASE_PATH`-Konstante beim Modul-Import einmalig aus
+// `process.env.NEXT_PUBLIC_BASE_PATH` gelesen wird (siehe lib/base-path.ts und
+// lib/__tests__/base-path.test.ts). `vi.stubEnv()` nach dem ersten Import ändert
+// diese bereits ausgewertete Konstante nicht mehr rückwirkend — deshalb hier
+// wie dort: Module nach jeder Env-Änderung per `vi.resetModules()` frisch laden.
+async function importWithEnv(basePath: string | undefined, siteUrl: string) {
+  vi.resetModules()
+  if (basePath === undefined) {
+    delete process.env.NEXT_PUBLIC_BASE_PATH
+  } else {
+    process.env.NEXT_PUBLIC_BASE_PATH = basePath
+  }
+  process.env.NEXT_PUBLIC_SITE_URL = siteUrl
+  const [{ getAuthRequestOrigin }, { getAccountExpiredUrl, getCharacterUrl }] = await Promise.all([
+    import('../auth-request-origin'),
+    import('../auth-redirect'),
+  ])
+  return { getAuthRequestOrigin, getAccountExpiredUrl, getCharacterUrl }
+}
+
+describe('getAuthRequestOrigin', () => {
+  const originalBasePath = process.env.NEXT_PUBLIC_BASE_PATH
+  const originalSiteUrl = process.env.NEXT_PUBLIC_SITE_URL
+
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    if (originalBasePath === undefined) delete process.env.NEXT_PUBLIC_BASE_PATH
+    else process.env.NEXT_PUBLIC_BASE_PATH = originalBasePath
+    if (originalSiteUrl === undefined) delete process.env.NEXT_PUBLIC_SITE_URL
+    else process.env.NEXT_PUBLIC_SITE_URL = originalSiteUrl
+    vi.resetModules()
+  })
+
+  it.each(['/preview', '/uat'])(
+    'nutzt die vertrauenswürdige externe HTTPS-Origin und behält das %s-Präfix',
+    async (basePath) => {
+      const { getAuthRequestOrigin, getAccountExpiredUrl, getCharacterUrl } = await importWithEnv(
+        basePath,
+        'https://focus.lang-jamin.de',
+      )
+      const request = new Request('http://localhost:3000/auth/callback?code=abc', {
+        headers: {
+          'x-forwarded-host': 'focus.lang-jamin.de',
+          'x-forwarded-proto': 'https',
+        },
+      })
+
+      const origin = getAuthRequestOrigin(request)
+
+      expect(origin).toBe('https://focus.lang-jamin.de')
+      expect(getAccountExpiredUrl(origin)).toBe(`https://focus.lang-jamin.de${basePath}/account?error=expired`)
+      expect(getCharacterUrl(origin)).toBe(`https://focus.lang-jamin.de${basePath}/character`)
+    },
+  )
+
+  it('weist nicht vertrauenswürdige Forwarded-Hosts/-Protokolle zurück', async () => {
+    const { getAuthRequestOrigin } = await importWithEnv(undefined, 'https://focus.lang-jamin.de')
+    const request = new Request('http://localhost:3000/auth/callback?code=abc', {
+      headers: {
+        'x-forwarded-host': 'attacker.example',
+        'x-forwarded-proto': 'http',
+      },
+    })
+
+    expect(getAuthRequestOrigin(request)).toBe('https://focus.lang-jamin.de')
+  })
+})

--- a/lib/auth-redirect.ts
+++ b/lib/auth-redirect.ts
@@ -1,0 +1,15 @@
+import { withBasePath } from './base-path'
+
+export function getAuthCallbackUrl(origin: string): string {
+  return new URL(withBasePath('/auth/callback'), origin).toString()
+}
+
+export function getAccountExpiredUrl(origin: string): string {
+  const url = new URL(withBasePath('/account'), origin)
+  url.searchParams.set('error', 'expired')
+  return url.toString()
+}
+
+export function getCharacterUrl(origin: string): string {
+  return new URL(withBasePath('/character'), origin).toString()
+}

--- a/lib/auth-request-origin.ts
+++ b/lib/auth-request-origin.ts
@@ -1,0 +1,33 @@
+const LOCAL_ORIGIN = 'http://localhost:3000'
+
+function getConfiguredOrigin(): string {
+  const configuredUrl = process.env.NEXT_PUBLIC_SITE_URL ?? LOCAL_ORIGIN
+  const url = new URL(configuredUrl)
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('NEXT_PUBLIC_SITE_URL must use HTTP or HTTPS.')
+  }
+
+  return url.origin
+}
+
+function firstForwardedHeaderValue(value: string | null): string | null {
+  return value?.split(',', 1)[0]?.trim() || null
+}
+
+export function getAuthRequestOrigin(request: Request): string {
+  const configuredOrigin = getConfiguredOrigin()
+  const forwardedHost = firstForwardedHeaderValue(request.headers.get('x-forwarded-host'))
+  const forwardedProto = firstForwardedHeaderValue(request.headers.get('x-forwarded-proto'))
+
+  if (!forwardedHost || !forwardedProto) {
+    return configuredOrigin
+  }
+
+  try {
+    const forwardedOrigin = new URL(`${forwardedProto}://${forwardedHost}`).origin
+    return forwardedOrigin === configuredOrigin ? forwardedOrigin : configuredOrigin
+  } catch {
+    return configuredOrigin
+  }
+}


### PR DESCRIPTION
## Summary
- Behebt den auf #51 gemeldeten Live-Blocker: `app/auth/callback/route.ts` nutzte `url.origin`, was hinter dem NGINX-Reverse-Proxy auf die interne Adresse (`localhost:PORT`) zeigt statt auf den öffentlichen Host `https://focus.lang-jamin.de`.
- `lib/auth-request-origin.ts`: liest `X-Forwarded-Host`/`X-Forwarded-Proto`, validiert sie gegen die konfigurierte `NEXT_PUBLIC_SITE_URL` und fällt bei Abweichung auf die konfigurierte Origin zurück — verhindert Header-gesteuerte Redirects auf beliebige Hosts.
- `lib/auth-redirect.ts`: bündelt die drei Auth-Redirect-Ziele (Callback/Account-Expired/Character) einheitlich mit `withBasePath()`.
- `app/auth/callback/route.ts`, `app/account/account-form.tsx` nutzen die neuen Helfer statt manuell zusammengesetzter URLs.
- 5 SVG-Audio-Pfade in `quest-runner.tsx` zusätzlich auf `withBasePath()` umgestellt (waren bisher übersehen).

## Vorfall: Commit durch Force-Push verloren, wiederhergestellt
Ein Force-Push auf diesem Branch (07:31 Uhr) hat den ursprünglichen Fix-Commit versehentlich verworfen — die PR-Beschreibung beschrieb danach Arbeit, die im Diff nicht mehr enthalten war. Der Commit (`b9571b2`) existierte noch im Repo und wurde wiederhergestellt, auf den aktuellen `main` rebased, und dabei zwei echte Probleme behoben, die beim Rebase sichtbar wurden:
- doppelter `withBasePath`-Import in vier Dateien (stiller Merge-Fehler, kein Funktionsverlust)
- Modul-Cache-Bug in zwei neuen Testdateien: `vi.stubEnv()` nach dem ersten Import ändert die bereits ausgewertete `BASE_PATH`-Konstante nicht mehr rückwirkend — auf dasselbe `vi.resetModules()`-Muster wie `lib/__tests__/base-path.test.ts` umgestellt.

## Verification
- `npm run lint` — PASS (0 Fehler, 2 vorbestehende Warnings)
- `npm run typecheck` — PASS
- `npm test` — PASS (11 Dateien, 113 Tests)
- `npm run build` (mit `NEXT_BASE_PATH=/preview`, echter `NEXT_PUBLIC_SITE_URL`) — PASS
- **Echter End-to-End-Test:** `server.js` gestartet, `/preview/auth/callback` per curl angefragt — ohne Forwarded-Header, mit echten `X-Forwarded-*`-Headern wie hinter NGINX, und mit einem gefälschten `X-Forwarded-Host` (Spoofing-Versuch). Alle drei Fälle liefern korrekt `https://focus.lang-jamin.de/preview/account?error=expired` — nie `localhost`, nie den gefälschten Host.

## Scope / exclusions
- Keine DNS-, TLS-, VPS-, Supabase-, Datenbank- oder Secret-Änderungen.
- #51 bleibt offen bis Live-Deployment und Project-Lead-Browserabnahme abgeschlossen sind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
