### PR TITLE
#junDev fix: Kontrastbruch Abenteuerbuch, Skip-Link, Fokus-Überschrift

### DIFF
--- a/app/adventure-book/adventure-book.module.css
+++ b/app/adventure-book/adventure-book.module.css
@@ -3,7 +3,7 @@
   padding: clamp(24px, 5vw, 72px);
   background:
     radial-gradient(circle at 50% 18%, rgb(212 167 44 / .08), transparent 32%),
-    #14110d;
+    var(--bg);
   color: var(--text);
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -38,6 +38,23 @@ html { background: var(--bg); color-scheme: dark light; }
 body { margin: 0; min-height: 100dvh; background: var(--bg); color: var(--text); font-family: var(--font-ui), sans-serif; caret-color: var(--accent); }
 ::selection { background: var(--selection); color: var(--selection-ink); }
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; box-shadow: 0 0 0 2px var(--bg); }
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 12px;
+  z-index: 100;
+  padding: 12px 20px;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: top 160ms ease-out;
+}
+.skip-link:focus-visible {
+  top: 12px;
+}
 * { scrollbar-color: var(--border-strong) var(--bg); }
 h1, h2, h3 { font-family: var(--font-display), serif; letter-spacing: .02em; text-wrap: balance; }
 p { color: var(--text-muted); text-wrap: pretty; max-width: 70ch; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,7 +43,10 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
   return (
     <html lang="de" suppressHydrationWarning>
       <head><script dangerouslySetInnerHTML={{ __html: themeScript }} /></head>
-      <body className={`${ui.variable} ${display.variable}`}>{children}</body>
+      <body className={`${ui.variable} ${display.variable}`}>
+        <a href="#main-content" className="skip-link">Zum Inhalt springen</a>
+        {children}
+      </body>
     </html>
   )
 }

--- a/app/quest/first-light/quest-runner.tsx
+++ b/app/quest/first-light/quest-runner.tsx
@@ -347,7 +347,10 @@ function FocusScene({
       </svg>
 
       <div className={styles.timerPanel}>
-        <p className="eyebrow" id="focus-title">
+        <h1 id="focus-title" className={styles.visuallyHidden}>
+          Ein Licht im Unterholz
+        </h1>
+        <p className="eyebrow">
           Ein Licht im Unterholz
         </p>
         <p className={styles.timer} aria-hidden="true">


### PR DESCRIPTION
Teil von #18

Setzt die drei priorisierten Funde aus dem #18-Vorprüf-Audit-Kommentar um (kein Design-/Produktentscheid nötig, keine sichtbare Textänderung):

1. **Kontrastbruch `/adventure-book` (hell)** — `app/adventure-book/adventure-book.module.css`: hartkodierten Hex-Wert `#14110d` durch `var(--bg)` ersetzt. Zuvor blieb der Hintergrund im hellen Modus fälschlich beim dunklen Wert hängen (Text auf Hintergrund ≈ 1,12:1 bzw. ≈ 2,88:1 statt ≥ 4,5:1). Analog zum bereits korrekten Muster in `account.module.css`.
2. **Fehlender Skip-Link** — neuer `<a href="#main-content" className="skip-link">Zum Inhalt springen</a>` als erstes fokussierbares Element im `<body>` (`app/layout.tsx`), Styling zentral in `app/globals.css` (außerhalb des Viewports, bei `:focus-visible` sichtbar, Farben aus den Theme-Tokens). Springt zum bereits überall vorhandenen `id="main-content"`.
3. **Fehlende Überschrift in der Fokus-Stage** — `app/quest/first-light/quest-runner.tsx`: visuell verstecktes `<h1 id="focus-title" className={styles.visuallyHidden}>` ergänzt (nutzt die vorhandene `.visuallyHidden`-Utility), damit der meistgenutzte Bildschirm über die Überschriften-Navigation (Screenreader) auffindbar ist. Sichtbare `eyebrow`-Zeile bleibt unverändert, keine Duplicate-ID (die `id` wandert vom `<p>` auf das neue `<h1>`, `aria-labelledby` auf der `<section>` bleibt unverändert gültig).

**Bewusst nicht in diesem PR:** Der identische Fund im Katalog-Runner (`app/quest/catalog/[questKey]/quest-runner.tsx`) — diese Datei existiert nur im noch offenen, nicht gemergten PR #79 (Branch `dev/issue-26-quest-catalog`) und nicht auf `main` (verifiziert per `git log`/`gh pr list` vor Start). Wird stattdessen als Review-Hinweis auf #79 vermerkt bzw. als Folge-PR nachgezogen, sobald #79 gemergt ist.

## Verifikation

- `npm run lint` — grün (nur 2 vorbestehende, unveränderte Warnings in `eslint.config.mjs`/`postcss.config.mjs`)
- `npm run typecheck` — grün
- `npm run test` — grün (113/113 Tests)
- `npm run build` — grün

**Screenshots:** Kein Browser-/Preview-Zugriff in dieser Session verfügbar — daher keine visuellen Screenshots hell/dunkel gemacht, obwohl WORKFLOW.md das bei UI-Änderungen verlangt. Alle drei Fixes sind mechanisch (CSS-Variable, unsichtbares Element, versteckte Überschrift) und wurden stattdessen durch Code-Review der Diffs sowie die grüne Build-/Test-Pipeline abgesichert. Bitte vor Merge ggf. manuell hell/dunkel gegenprüfen, insbesondere Fund 1 (nur im hellen Modus sichtbar) und den Skip-Link-Fokuszustand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)