### PR TITLE
#SENDEV Seed-Herkunfts-Contract für Loot-Ziehung vor Verdrahtung festschreiben

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -98,6 +98,13 @@ Drei persistente Akte mit Rasten; Boss/Höhepunkt in Akt III. Kein 90-Minuten-Da
 **Grund:** Verhindert ein unbeabsichtigtes Pausieren des Projekts während längerer Entwicklungspausen, mit minimaler, klar abgegrenzter Schreibfläche.  
 **Offener Punkt:** Das ausführende Script (\`~/.hermes/scripts/pomodoro_dnd_heartbeat.py\`) läuft aktuell außerhalb dieses Repositories, in HERMES' eigener Umgebung, mit dem vollprivilegierten \`service_role\`-Key — für niemand sonst einsehbar oder review-fähig. Sollte perspektivisch als Skript ins Repo (z. B. \`scripts/\`) überführt werden, damit auch der Automatisierungscode selbst der "Was nicht in GitHub steht, existiert nicht"-Regel aus `docs/WORKFLOW.md` folgt.
 
+### ADR-041 · Seed-Erzeugung für Loot-Ziehung bleibt außerhalb von `draw.ts`, serverseitig, per CSPRNG
+**Status:** angenommen · 2026-09-07  
+**Kontext:** `lib/loot/draw.ts` zieht Loot deterministisch aus einem `seed`-String über einen öffentlich nachvollziehbaren, nicht-kryptografischen 32-Bit-Hash. Das ist beabsichtigt für Testbarkeit, macht aber die Herkunft des `seed` sicherheitskritisch: Wer den Wert kennt oder billig neu erzeugen kann, kann das Ziehungsergebnis vorausberechnen. `draw.ts` ist noch an keinen echten Endpunkt angebunden (siehe #75).  
+**Entscheidung:** Die Erzeugung des `seed` bleibt außerhalb von `draw.ts` — Aufgabe der künftigen, noch zu bauenden Chest-Open-RPC. Sie muss serverseitig, per CSPRNG (`gen_random_uuid()`/`gen_random_bytes()`) und erst zum tatsächlichen Ziehungszeitpunkt erfolgen, niemals abgeleitet aus einem dem Client vorab bekannten Wert wie `focus_sessions.id`. `draw.ts` selbst dokumentiert diesen Contract (siehe Kommentar über `hash()`/`rollRarity()`/`drawLoot()`), ändert aber weder Signatur noch Verhalten.  
+**Alternative:** CSPRNG direkt in `draw.ts` einbauen, z. B. `seed` optional selbst erzeugen lassen.  
+**Grund:** Würde Determinismus, Testbarkeit und Nachvollziehbarkeit der reinen Funktion zerstören, ohne die eigentliche Schwachstelle — die Seed-Herkunft beim künftigen Aufrufer — zu beheben.
+
 ---
 
 ## Concept-V2-Entscheidungen

--- a/lib/loot/draw.ts
+++ b/lib/loot/draw.ts
@@ -13,6 +13,28 @@
  * Ergebnis, was eine serverseitige Ziehung testbar und nachvollziehbar macht. Das
  * ist unabhängig von Party-Fragen: Nach ADR-025 gibt es keine Party-Truhe, jede
  * Person erhält eine eigene, individuelle Ziehung.
+ *
+ * SEED-HERKUNFTS-CONTRACT (siehe #75, ADR-041) — bindend für jeden künftigen Aufrufer:
+ *
+ *   1. Der `seed` MUSS serverseitig erzeugt werden, und zwar erst im Moment der
+ *      tatsächlichen Ziehung — frisch per kryptografischem Zufall (z. B.
+ *      `gen_random_uuid()`/`gen_random_bytes()` innerhalb der `security definer`-
+ *      Funktion, die die Truhe öffnet). `hash()` selbst ist absichtlich kein
+ *      kryptografischer Hash — die Sicherheit der Ziehung hängt vollständig davon
+ *      ab, dass der `seed` bereits unvorhersagbar ist, bevor er hier ankommt.
+ *   2. Der `seed` DARF NIEMALS aus einem Wert abgeleitet werden, der dem Client vor
+ *      der Ziehung schon bekannt ist oder von ihm billig neu erzeugt werden kann.
+ *      Explizit ausgeschlossen: `focus_sessions.id` (wird per RPC-Rückgabewert an
+ *      den Client ausgeliefert), Zeitstempel, sowie jeder Client-Parameter.
+ *   3. Der Seed bzw. ein Vorschau-Ergebnis der Ziehung DARF NIEMALS an den Client
+ *      ausgeliefert werden, bevor der Reward persistiert ist — kein "Preview"-
+ *      Endpunkt.
+ *
+ *   Diese drei Punkte sind eine Anforderung an den künftigen Aufrufer (die noch zu
+ *   bauende Chest-Open-RPC), NICHT an diese Datei: `hash()`, `rollRarity()` und
+ *   `drawLoot()` bleiben pure, deterministische Funktionen ohne Math.random(),
+ *   CSPRNG-Aufruf, Uhr oder neue Parameter — genau das macht sie testbar
+ *   (`lib/loot/__tests__/draw.test.ts`).
  */
 
 export type Category = 'charakter' | 'lager' | 'begleiter' | 'atmosphaere'


### PR DESCRIPTION
## Zusammenfassung

Setzt Issue #75 vollständig um: reine Contract-/Doku-Vorbereitung, bevor `drawLoot`/`rollRarity` an einen echten Endpunkt angebunden werden.

- `lib/loot/draw.ts`: unübersehbarer Contract-Kommentar über `hash()`/`rollRarity()`/`drawLoot()`. Hält verbindlich fest, dass der `seed`-Parameter serverseitig, per CSPRNG (`gen_random_uuid()`/`gen_random_bytes()`) und erst zum tatsächlichen Ziehungszeitpunkt erzeugt werden muss — niemals abgeleitet aus `focus_sessions.id`, Zeitstempeln oder anderen Client-Werten, und dass Seed/Vorschau-Ergebnis nie vor Persistierung des Rewards an den Client geht. Verweist auf #75 und ADR-041.
- `docs/DECISIONS.md`: neuer Eintrag **ADR-041** (nächste freie Nummer nach ADR-040) im bestehenden Vier-Zeilen-Format — Entscheidung, dass Seed-Erzeugung außerhalb von `draw.ts` bleibt; verworfene Alternative war CSPRNG direkt in `draw.ts`.

## Explizit NICHT enthalten (wie im Issue-Scope gefordert)

- Keine neue `supabase/migrations/*.sql`-Datei / keine echte Chest-Open-RPC.
- Keine Änderung an Signatur, Algorithmus oder Verhalten von `hash()`, `rollRarity()`, `drawLoot()` — bleiben pure/deterministisch.
- Kein Wiring von `drawLoot`/`rollRarity` in UI oder RPC — `grep -rn "drawLoot\|rollRarity"` außerhalb von `lib/loot/draw.ts` und `lib/loot/__tests__/` liefert weiterhin kein Ergebnis.
- Keine Anpassung an `lib/loot/__tests__/draw.test.ts` (unverändert grün).

## Verifikation

Alle Pflicht-Checks lokal grün:
```
npm run lint       ✓ (nur 2 vorbestehende Warnings, unabhängig von diesem PR)
npm run typecheck  ✓
npm run test        113/113 Tests grün, inkl. draw.test.ts (21 Tests) unverändert
npm run build       ✓
```

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)